### PR TITLE
add link to open the current map view in OSM editor

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -58,7 +58,7 @@ $ cd OpenRailwayMap
 
  For system-specific installation of Cairo view the [node-canvas Wiki](https://github.com/LearnBoost/node-canvas/wiki/_pages).
 
- Install Leaflet:
+ Install Leaflet and the Leaflet extension that provides the edit link:
 
 ```shell
 $ make install-deps

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 SHELL = /bin/sh -e
 DEP_LEAFLET_VERSION = 0.7.7
+DEP_LEAFLET_EDITOR_FILES = download/Leaflet.EditInOSM.js download/Leaflet.EditInOSM.css download/edit-in-osm.png
 
 .PHONY: check all
 
@@ -33,7 +34,12 @@ download/leaflet-$(DEP_LEAFLET_VERSION).zip:
 	wget -O download/leaflet.zip https://cdn.leafletjs.com/leaflet/v$(DEP_LEAFLET_VERSION)/leaflet.zip
 	mv download/leaflet.zip download/leaflet-$(DEP_LEAFLET_VERSION).zip
 
-download-deps: download/leaflet-$(DEP_LEAFLET_VERSION).zip
+$(DEP_LEAFLET_EDITOR_FILES):
+	wget -O $@.tmp https://raw.githubusercontent.com/yohanboniface/Leaflet.EditInOSM/master/$(notdir $@)
+	mv $@.tmp $@
+
+download-deps:	download/leaflet-$(DEP_LEAFLET_VERSION).zip \
+		$(DEP_LEAFLET_EDITOR_FILES)
 
 css/leaflet.css: download/leaflet-$(DEP_LEAFLET_VERSION).zip
 	mkdir -p download/leaflet-extract js/images; \
@@ -45,4 +51,10 @@ css/leaflet.css: download/leaflet-$(DEP_LEAFLET_VERSION).zip
 	sed s,images/,../js/images/, leaflet.css > ../leaflet.css; \
 	mv ../leaflet.css ../../css/
 
-install-deps: css/leaflet.css
+css/Leaflet.EditInOSM.css: $(DEP_LEAFLET_EDITOR_FILES)
+	cp download/Leaflet.EditInOSM.js js/
+	cp download/edit-in-osm.png img/
+	sed 's#"./edit-in-osm#"../img/edit-in-osm#' download/Leaflet.EditInOSM.css > download/Leaflet.EditInOSM.css_
+	mv download/Leaflet.EditInOSM.css_ $@
+
+install-deps: css/leaflet.css css/Leaflet.EditInOSM.css

--- a/canvas.php
+++ b/canvas.php
@@ -47,6 +47,8 @@
 		<link rel="stylesheet" type="text/css" href="css/leaflet.css" />
 
 		<script type="text/javascript" src="js/leaflet.js"></script>
+		<link rel="stylesheet" href="css/Leaflet.EditInOSM.css" />
+		<script src="js/Leaflet.EditInOSM.js"></script>
 		<script type="text/javascript" src="js/L.TileLayer.Grayscale.js"></script>
 		<script type="text/javascript" src="renderer/kothic/kothic.js"></script>
 		<script type="text/javascript" src="renderer/kothic/renderer/path.js"></script>

--- a/index.php
+++ b/index.php
@@ -47,6 +47,8 @@
 		<link rel="stylesheet" type="text/css" href="css/leaflet.css" />
 
 		<script type="text/javascript" src="js/leaflet.js"></script>
+		<link rel="stylesheet" href="css/Leaflet.EditInOSM.css" />
+		<script src="js/Leaflet.EditInOSM.js"></script>
 		<script type="text/javascript" src="js/L.TileLayer.Grayscale.js"></script>
 		<?php
 			urlArgsToParam(true, $urlbase);

--- a/js/bitmap-map.js
+++ b/js/bitmap-map.js
@@ -58,7 +58,7 @@ function createMap(embed)
 			offset = -(now.getTimezoneOffset() / 60);
 		}
 
-		map = L.map('mapFrame');
+		map = L.map('mapFrame', { editInOSMControlOptions: { zoomThreshold: 14, editors: [ 'josm' ] }, });
 
 		if (!embed)
 		{

--- a/js/canvas-map.js
+++ b/js/canvas-map.js
@@ -59,7 +59,7 @@ function createMap(embed)
 			offset = -(now.getTimezoneOffset() / 60);
 		}
 
-		map = L.map('mapFrame');
+		map = L.map('mapFrame', { editInOSMControlOptions: { zoomThreshold: 14, editors: [ 'josm' ] }, });
 
 		map.on('moveend', function(e)
 		{

--- a/js/mobile.js
+++ b/js/mobile.js
@@ -58,7 +58,7 @@ function createMap(embed)
 			offset = -(now.getTimezoneOffset() / 60);
 		}
 
-		map = L.map('mapFrame');
+		map = L.map('mapFrame', { editInOSMControlOptions: { zoomThreshold: 14, editors: [ 'josm' ] }, });
 
 		if (!embed)
 		{

--- a/mobile.php
+++ b/mobile.php
@@ -47,6 +47,8 @@
 		<link rel="stylesheet" type="text/css" href="css/leaflet.css" />
 
 		<script type="text/javascript" src="js/leaflet.js"></script>
+		<link rel="stylesheet" href="css/Leaflet.EditInOSM.css" />
+		<script src="js/Leaflet.EditInOSM.js"></script>
 		<script type="text/javascript" src="js/L.TileLayer.Grayscale.js"></script>
 		<script>L_DISABLE_3D = true;</script>
 


### PR DESCRIPTION
The button is only show from zoom level 14 on as otherwise the area is too big to edit. Only JOSM is enabled as editor as iD is known to break relations during editing.

Fixes #39.
