### PR TITLE
styles: do not set style for otherwise unmatched tracks in non-standard layers in JOSM

### DIFF
--- a/styles/electrified.mapcss
+++ b/styles/electrified.mapcss
@@ -148,12 +148,14 @@ way["construction:voltage"]["construction:frequency"].ectracks
 	dashes: 5,5;
 }
 
-way[!electrified].tracks,
-way[electrified!=no][!voltage].tracks,
-way[electrified!=no][!frequency].tracks
-{
-	z-index: 0;
-	color: gray;
+@supports not (user-agent: josm) {
+	way[!electrified].tracks,
+	way[electrified!=no][!voltage].tracks,
+	way[electrified!=no][!frequency].tracks
+	{
+		z-index: 0;
+		color: gray;
+	}
 }
 
 way[electrified=no].tracks,

--- a/styles/maxspeed.mapcss
+++ b/styles/maxspeed.mapcss
@@ -47,12 +47,14 @@ way.tracks_preserved
 	set .tracks;
 }
 
-way[!maxspeed].tracks
-{
-	z-index: 0;
-	color: gray;
-	width: 3.5;
-	kothicjs-ignore-layer: true;
+@supports not (user-agent: josm) {
+	way[!maxspeed].tracks
+	{
+		z-index: 0;
+		color: gray;
+		width: 3.5;
+		kothicjs-ignore-layer: true;
+	}
 }
 
 way.tracks_construction,

--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -40,13 +40,15 @@ way[!"construction:railway"]["construction"=rail]["construction:railway:etcs"]["
 	set .ctracks;
 }
 
-way.tracks,
-way.ctracks
-{
-	z-index: 0;
-	color: gray;
-	width: 3.5;
-	kothicjs-ignore-layer: true;
+@supports not (user-agent: josm) {
+	way.tracks,
+	way.ctracks
+	{
+		z-index: 0;
+		color: gray;
+		width: 3.5;
+		kothicjs-ignore-layer: true;
+	}
 }
 
 way["railway:pzb"=no]["railway:lzb"=no][!"railway:etcs"].tracks,


### PR DESCRIPTION
JOSM may load several styles at once. Avoid setting the default gray style for all lines that are not matched by more specific rules in a given style, so that stacking the styles will allow the color of the underlying style shine through.
