### PR TITLE
search: only search for uicref or name, never both

### DIFF
--- a/js/search.js
+++ b/js/search.js
@@ -54,39 +54,41 @@ function Search(map, box, bar, searchButton, clearButton, mobilemenu)
 			this.bar.innerHTML += "<div class=\"loadingMoreInfo\">"+loading+"</div>";
 			this.request = input;
 
-			this.sendRequest("facility", "uicref="+input, function(response)
+			queryRef = function(response)
 			{
 				self.showResults(response);
-				self.sendRequest("facility", "ref="+input, function(response)
+				self.sendRequest("facility", "ref=" + input, function(response)
 				{
-					self.showResults(response);
-					self.sendRequest("facility", "name="+input, function(response)
-					{
-						var words = input.split(" ");
-						for (var i=0; i<words.length; i++)
-						{
-							if (/[0-9][.,][0-9]/.test(words[i]))
-							{
-								var pos = words[i];
-								words.splice(i, 1);
-								break;
-							}
-						}
-
-						if (pos)
-						{
-							var ref = words.join(" ");
-
-							self.sendRequest("milestone", "position=" + pos.replace(',', '.') + "&ref=" + ref, function(response)
-							{
-								self.finishResults(response);
-							});
-						}
-						else
-							self.finishResults(response);
-					});
+					self.finishResults(response);
 				});
-			});
+			}
+
+			if((input.length != 7) || isNaN(input)) {
+				self.sendRequest("facility", "name=" + input, function(response)
+				{
+					var words = input.split(" ");
+					for (var i = 0; i<words.length; i++)
+					{
+						if (/[0-9][.,][0-9]/.test(words[i]))
+						{
+							var pos = words[i];
+							words.splice(i, 1);
+							break;
+						}
+					}
+
+					if (pos)
+					{
+						var ref = words.join(" ");
+
+						self.sendRequest("milestone", "position=" + pos.replace(',', '.') + "&ref=" + ref, queryRef);
+					}
+					else
+						queryRef(response);
+				});
+			} else {
+				this.sendRequest("facility", "uicref=" + input, queryRef);
+			}
 		}
 	}
 


### PR DESCRIPTION
The uicref search has a strict format supported by the API, which is "7 digits". Check this before sending the search request to avoid wasting everyones time. Also assume that a valid uicref is not a valid name, simply because it doesn't make any sense.