### PR TITLE
JOSM presets: use <chunk> and <reference> for "railway:signal:direction"

### DIFF
--- a/josm-presets/at-signals-v2.xml
+++ b/josm-presets/at-signals-v2.xml
@@ -12,6 +12,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 
 
 <presets xmlns="http://josm.openstreetmap.de/tagging-preset-1.0" author="OpenRailwayMap" version="1.0" shortdescription="OpenRailwayMap Signale AT V2" description="Preset to tag Austrian railway signals">
+	<chunk id="direction_fw_bw">
+		<combo key="railway:signal:direction"
+			text="Direction"
+			de.text="Anzeigerichtung"
+			values="forward,backward"
+			display_values="in direction of OSM way,against direction of OSM way"
+			de.display_values="In Wegrichtung,Entgegen Wegrichtung"
+			/>
+	</chunk>
+	<chunk id="direction_fw_bw_b">
+		<combo key="railway:signal:direction"
+			text="Direction"
+			de.text="Anzeigerichtung"
+			values="forward,backward,both"
+			display_values="in direction of OSM way,against direction of OSM way,both directions"
+			de.display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
+			/>
+	</chunk>
 	<group name="OpenRailwayMap Signale AT V2" icon="signals.png">
 		<item name="Formhauptsignal" type="node" icon="de/hp1-semaphore-38.png" >
 			<label text="Formhauptsignal" />
@@ -33,12 +51,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:main"
 				value="AT-V2:hauptsignal" />
@@ -96,12 +109,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:main"
 				value="AT-V2:hauptsignal" />
@@ -161,12 +169,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:distant"
 				value="AT-V2:vorsignal" />
@@ -203,12 +206,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:distant"
 				value="AT-V2:vorsignal" />
@@ -247,12 +245,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:main"
 				value="AT-V2:trapeztafel" />
@@ -283,12 +276,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:distant"
 				value="AT-V2:kreuztafel" />
@@ -316,12 +304,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Gleismitte/am Prellbock"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:minor"
 				value="AT-V2:schutzsignal" />
@@ -368,12 +351,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:minor"
 				value="AT-V2:sperrsignal" />
@@ -408,12 +386,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward,both"
-				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-				/>
+			<reference ref="direction_fw_bw_b" />
 			<space />
 			<key key="railway:signal:minor"
 				value="AT-V2:weiterfahrt_verboten" />
@@ -442,12 +415,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:minor"
 				value="AT-V2:haltscheibe" />
@@ -482,12 +450,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:shunting"
 					value="AT-V2:verschubsignal" />
@@ -518,12 +481,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:shunting"
 					value="AT-V2:verschubhalttafel" />
@@ -552,12 +510,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:shunting"
 					value="AT-V2:wartesignal" />
@@ -586,12 +539,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:shunting"
 					value="AT-V2:wartesignal" />
@@ -622,12 +570,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:humping"
 					value="AT-V2:abdrücksignal" />
@@ -660,12 +603,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:speed_limit"
 				value="AT-V2:geschwindigkeitsanzeiger" />
@@ -704,12 +642,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:speed_limit_distant"
 				value="AT-V2:geschwindigkeitvorsanzeiger" />
@@ -748,12 +681,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:speed_limit"
 				value="AT-V2:geschwindigkeitstafel" />
@@ -793,12 +721,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:speed_limit_distant"
 				value="AT-V2:ankündigungstafel" />
@@ -833,12 +756,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:speed_limit_distant"
 					value="AT-V2:ankündigungssignal" />
@@ -872,12 +790,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:speed_limit"
 					value="AT-V2:anfangssignal" />
@@ -911,12 +824,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:speed_limit"
 					value="AT-V2:endsignal" />
@@ -949,12 +857,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,overhead"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<combo key="railway:signal:electricity"
 				text="Exact type"
@@ -999,12 +902,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,overhead"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:electricity"
 				value="AT-V2:schaltzeiger" />
@@ -1033,12 +931,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:crossing"
 					value="AT-V2:ek_überwachungssignal" />
@@ -1063,12 +956,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:crossing_hint"
 					value="AT-V2:eküs" />
 				<key key="railway:signal:crossing_hint:form"
@@ -1100,12 +988,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:crossing_info"
 					value="AT-V2:eküs" />
 				<key key="railway:signal:crossing_info:form"
@@ -1137,12 +1020,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:crossing_distant"
 					value="AT-V2:rautentafel" />
@@ -1165,12 +1043,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:crossing_distant"
 					value="AT-V2:schaltstellenpflock" />
@@ -1197,12 +1070,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:whistle"
 					value="AT-V2:pfeifpflock" />
@@ -1225,12 +1093,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:whistle"
 					value="AT-V2:gruppenpfeifpflock" />
@@ -1253,12 +1116,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right,bridge"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:whistle"
 					value="AT-V2:endpflock" />
@@ -1282,12 +1140,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<key key="railway:signal:stop"
 				value="AT-V2:haltepunkt" />
 			<key key="railway:signal:stop:form"
@@ -1319,12 +1172,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<key key="railway:signal:station_distant"
 				value="AT-V2:haltestellentafel" />
 			<key key="railway:signal:station_distant:form"
@@ -1346,12 +1194,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:resetting_switch"
 				value="AT-V2:weichenüberwachungssignal" />
@@ -1442,12 +1285,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward,both"
-				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-				/>
+			<reference ref="direction_fw_bw_b" />
 			<key key="railway:signal:brake_test"
 				value="AT-V2:bremsprobesignal" />
 			<key key="railway:signal:brake_test:form"
@@ -1471,12 +1309,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward,both"
-				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-				/>
+			<reference ref="direction_fw_bw_b" />
 			<key key="railway:signal:departure"
 				value="AT-V2:abfahrt" />
 			<key key="railway:signal:departure:form"
@@ -1498,12 +1331,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward,both"
-				display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-				/>
+			<reference ref="direction_fw_bw_b" />
 			<key key="railway:signal:departure"
 				value="AT-V2:fahrerlaubnissignal" />
 			<combo key="railway:signal:departure:form"
@@ -1534,12 +1362,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:snowplow"
 					value="AT-V2:räumarbeit_einstellen" />
 				<key key="railway:signal:snowplow:form"
@@ -1563,12 +1386,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:snowplow"
 					value="AT-V2:mittelräumer_heben" />
 				<key key="railway:signal:snowplow:form"
@@ -1592,12 +1410,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:snowplow"
 					value="AT-V2:räumarbeit_aufnehmen" />
 				<key key="railway:signal:snowplow:form"
@@ -1622,12 +1435,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<check key="railway:signal:catenary_mast"
 				text="On catenary mast"
 				de.text="Am Oberleitungsmast"
@@ -1667,12 +1475,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:main_repeated"
 				value="AT-V2:signalnachahmer" />
@@ -1703,12 +1506,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:minor"
 				value="AT-V2:fahrwegende" />
@@ -1737,12 +1535,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,in_track"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:main:substitute_signal"
 				value="AT-V2:dienstruhe" />
@@ -1771,12 +1564,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<check key="railway:signal:catenary_mast"
 				text="On catenary mast"
 				de.text="Am Oberleitungsmast"

--- a/josm-presets/at-signals-v2.xml
+++ b/josm-presets/at-signals-v2.xml
@@ -12,6 +12,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 
 
 <presets xmlns="http://josm.openstreetmap.de/tagging-preset-1.0" author="OpenRailwayMap" version="1.0" shortdescription="OpenRailwayMap Signale AT V2" description="Preset to tag Austrian railway signals">
+	<chunk id="sig_ref">
+		<key key="railway"
+			value="signal" />
+		<text key="ref"
+			text="Signal ref"
+			de.text="Signalbezeichnung"
+			/>
+	</chunk>
 	<chunk id="direction_fw_bw">
 		<combo key="railway:signal:direction"
 			text="Direction"
@@ -35,12 +43,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<label text="Formhauptsignal" />
 			<label text="Wird als Punkt auf dem Gleis erfasst." />
 			<space />
-			<key key="railway"
-				value="signal" />
-			<text key="ref"
-				text="Signal ref"
-				de.text="Signalbezeichnung"
-				/>
+			<reference ref="sig_ref" />
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
@@ -93,12 +96,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<label text="Lichthauptsignal" />
 			<label text="Wird als Punkt auf dem Gleis erfasst." />
 			<space />
-			<key key="railway"
-				value="signal" />
-			<text key="ref"
-				text="Signal ref"
-				de.text="Signalbezeichnung"
-				/>
+			<reference ref="sig_ref" />
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
@@ -153,12 +151,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<label text="Formvorsignal" />
 			<label text="Wird als Punkt auf dem Gleis erfasst." />
 			<space />
-			<key key="railway"
-				value="signal" />
-			<text key="ref"
-				text="Signal ref"
-				de.text="Signalbezeichnung"
-				/>
+			<reference ref="sig_ref" />
 			<check key="railway:signal:distant:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
@@ -190,12 +183,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<label text="Lichtvorsignal" />
 			<label text="Wird als Punkt auf dem Gleis erfasst." />
 			<space />
-			<key key="railway"
-				value="signal" />
-			<text key="ref"
-				text="Signal ref"
-				de.text="Signalbezeichnung"
-				/>
+			<reference ref="sig_ref" />
 			<check key="railway:signal:distant:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
@@ -288,12 +276,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<label text="Schutzsignal" />
 			<label text="Wird als Punkt auf dem Gleis erfasst." />
 			<space />
-			<key key="railway"
-				value="signal" />
-			<text key="ref"
-				text="Signal ref"
-				de.text="Signalbezeichnung"
-				/>
+			<reference ref="sig_ref" />
 			<check key="railway:signal:minor:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
@@ -335,12 +318,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<label text="Sperrsignal, verstellbar" />
 			<label text="Wird als Punkt auf dem Gleis erfasst." />
 			<space />
-			<key key="railway"
-				value="signal" />
-			<text key="ref"
-				text="Signal ref"
-				de.text="Signalbezeichnung"
-				/>
+			<reference ref="sig_ref" />
 			<check key="railway:signal:minor:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
@@ -370,12 +348,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<label text="Sperrsignal, fix" />
 			<label text="Wird als Punkt auf dem Gleis erfasst." />
 			<space />
-			<key key="railway"
-				value="signal" />
-			<text key="ref"
-				text="Signal ref"
-				de.text="Signalbezeichnung"
-				/>
+			<reference ref="sig_ref" />
 			<check key="railway:signal:minor:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
@@ -434,12 +407,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Verschubsignal" />
 				<label text="Wird als Punkt auf dem Gleis erfasst." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:shunting:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -1459,12 +1427,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<label text="Signalnachahmer" />
 			<label text="Wird als Punkt auf dem Gleis erfasst." />
 			<space />
-			<key key="railway"
-				value="signal" />
-			<text key="ref"
-				text="Signal ref"
-				de.text="Signalbezeichnung"
-				/>
+			<reference ref="sig_ref" />
 			<check key="railway:signal:main_repeated:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"

--- a/josm-presets/de-avg-signals.xml
+++ b/josm-presets/de-avg-signals.xml
@@ -12,6 +12,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 
 
 <presets xmlns="http://josm.openstreetmap.de/tagging-preset-1.0" author="OpenRailwayMap" version="1.0" shortdescription="OpenRailwayMap special AVG signals" description="Preset to tag some special railway signals used by Albtal-Verkehrs-Gesellschaft around Karlsruhe">
+	<chunk id="sig_ref">
+		<key key="railway"
+			value="signal" />
+		<text key="ref"
+			text="Signal ref"
+			de.text="Signalbezeichnung"
+			/>
+	</chunk>
 	<chunk id="direction_fw_bw">
 		<combo key="railway:signal:direction"
 			text="Direction"
@@ -26,12 +34,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<label text="Hp-Licht-Hauptsignal als Einfahrtsignal" />
 			<label text="Wird als Punkt auf dem Gleis erfasst." />
 			<space />
-			<key key="railway"
-				value="signal" />
-			<text key="ref"
-				text="Signal ref"
-				de.text="Signalbezeichnung"
-				/>
+			<reference ref="sig_ref" />
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
@@ -159,12 +162,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<label text="Fahrsignal  (F 0/F 1)" />
 			<label text="Wird als Punkt auf dem Gleis erfasst." />
 			<space />
-			<key key="railway"
-				value="signal" />
-			<text key="ref"
-				text="Signal ref"
-				de.text="Signalbezeichnung"
-				/>
+			<reference ref="sig_ref" />
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"

--- a/josm-presets/de-avg-signals.xml
+++ b/josm-presets/de-avg-signals.xml
@@ -12,6 +12,15 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 
 
 <presets xmlns="http://josm.openstreetmap.de/tagging-preset-1.0" author="OpenRailwayMap" version="1.0" shortdescription="OpenRailwayMap special AVG signals" description="Preset to tag some special railway signals used by Albtal-Verkehrs-Gesellschaft around Karlsruhe">
+	<chunk id="direction_fw_bw">
+		<combo key="railway:signal:direction"
+			text="Direction"
+			de.text="Anzeigerichtung"
+			values="forward,backward"
+			display_values="in direction of OSM way,against direction of OSM way"
+			de.display_values="In Wegrichtung,Entgegen Wegrichtung"
+			/>
+	</chunk>
 	<group name="OpenRailwayMap AVG-Signale" icon="signals.png">
 		<item name="Hp-Licht-Hauptsignal (AVG)" icon="de/hp2-light-32.png" type="node">
 			<label text="Hp-Licht-Hauptsignal als Einfahrtsignal" />
@@ -34,12 +43,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:main"
 				value="DE-ESO:hp" />
@@ -85,12 +89,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:distant"
 				value="DE-AVG:vf1" />
@@ -120,17 +119,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:crossing"
 				value="DE-AVG:bü200" />
 			<key key="railway:signal:crossing:states"
-				value="DE-AVG:bü200;DE-AVG:bü201"/>
+				value="DE-AVG:bü200;DE-AVG:bü201" />
 			<key key="railway:signal:crossing:form"
 				value="light" />
 		</item>
@@ -151,12 +145,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge,overhead"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:crossing_distant"
 				value="DE-AVG:bü200v" />
@@ -187,17 +176,12 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:main"
 				value="DE-AVG:f" />
 			<key key="railway:signal:main:form"
-				value="light"/>
+				value="light" />
 			<combo key="railway:signal:main:height"
 				text="Signal height"
 				de.text="Signalbauform"
@@ -205,7 +189,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				display_values="Mastbauform,Zwergsignal"
 				/>
 			<key key="railway:signal:main:states"
-				value="DE-AVG:f0;DE-AVG:f1"/>
+				value="DE-AVG:f0;DE-AVG:f1" />
 			<check key="railway:signal:route"
 				text="Display Track Number?"
 				de.text="Anzeige einer Gleisnummer?"
@@ -234,12 +218,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,overhead,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:switch"
 				value="DE-AVG:w" />
@@ -276,12 +255,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,overhead,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:switch"
 				value="DE-AVG:wv" />
@@ -314,12 +288,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,overhead"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<combo key="railway:signal:electricity"
 				text="Exact type"
@@ -334,7 +303,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				display_values="Mastbauform,Zwergsignal"
 				/>
 			<key key="railway:signal:electricity:type"
-				value="power_off_shortly"/>
+				value="power_off_shortly" />
 			<key key="railway:signal:electricity:form"
 				value="sign" />
 		</item>
@@ -356,12 +325,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<key key="railway:signal:request"
 				value="DE-AVG:st9" />
 			<key key="railway:signal:request:states"
@@ -387,12 +351,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung,"
-				/>
+			<reference ref="direction_fw_bw" />
 			<key key="railway:signal:departure"
 				value="DE-AVG:a1" />
 			<key key="railway:signal:departure:states"
@@ -418,12 +377,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung,"
-				/>
+			<reference ref="direction_fw_bw" />
 			<key key="railway:signal:train_protection"
 				value="DE-AVG:so1" />
 			<key key="railway:signal:train_protection:type"
@@ -448,12 +402,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung,"
-				/>
+			<reference ref="direction_fw_bw" />
 			<key key="railway:signal:train_protection"
 				value="DE-AVG:so2" />
 			<key key="railway:signal:train_protection:type"
@@ -478,12 +427,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung,"
-				/>
+			<reference ref="direction_fw_bw" />
 			<key key="railway:signal:loading_gauge"
 				value="DE-AVG:ra14" />
 			<key key="railway:signal:loading_gauge:form"
@@ -506,12 +450,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				values="left,right,bridge"
 				display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="In Wegrichtung,Entgegen Wegrichtung,"
-				/>
+			<reference ref="direction_fw_bw" />
 			<key key="railway:signal:stop_demand"
 				value="DE-AVG:hw1" />
 			<key key="railway:signal:stop_demand:states"

--- a/josm-presets/de-signals-bostrab.xml
+++ b/josm-presets/de-signals-bostrab.xml
@@ -12,6 +12,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 
 
 <presets xmlns="http://josm.openstreetmap.de/tagging-preset-1.0" author="OpenRailwayMap" version="1.0" shortdescription="OpenRailwayMap BOStrab signals" description="Preset to tag tram signals in Germany">
+	<chunk id="sig_ref">
+		<key key="railway"
+			value="signal" />
+		<text key="ref"
+			text="Signal ref"
+			de.text="Signalbezeichnung"
+			/>
+	</chunk>
 	<chunk id="direction_fw_bw">
 		<combo key="railway:signal:direction"
 			text="Direction"
@@ -27,12 +35,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				text="Fahrsignal  (F 0/F 1), umgangssprachlich auch Balkensignal genannt" />
 			<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 			<space />
-			<key key="railway"
-				value="signal" />
-			<text key="ref"
-				text="Signal ref"
-				de.text="Signalbezeichnung"
-				/>
+			<reference ref="sig_ref" />
 			<check key="railway:signal:main:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
@@ -72,12 +75,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Not in following cities: Hamburg, Stuttgart" de.text="Nicht in folgenden Städten: Hamburg, Stuttgart" />
 				<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:main:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -116,12 +114,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Not in following cities: Hamburg, Stuttgart" de.text="Nicht in folgenden Städten: Hamburg, Stuttgart" />
 				<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:combined:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -160,12 +153,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Not in following cities: Hamburg" de.text="Nicht in folgenden Städten: Hamburg" />
 				<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -204,12 +192,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<label text="Close doors (A 1), Depart (A 2)" de.text="Türen schließen (A 1), Abfahren (A 2)" />
 			<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 			<space />
-			<key key="railway"
-				value="signal" />
-			<text key="ref"
-				text="Signal ref"
-				de.text="Signalbezeichnung"
-				/>
+			<reference ref="sig_ref" />
 			<check key="railway:signal:departure:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
@@ -282,12 +265,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Distant Speed Limit Light Signal (G 1b)" de.text="Ankündigung einer Geschwindigkeitsbeschränkung (G 1b) als Leuchtanzeige" />
 				<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:speed_limit_distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -369,12 +347,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Speed Limit Light Signal (G 2b)" de.text="Beginn einer Geschwindigkeitsbeschränkung (G 2b) als Leuchtanzeige" />
 				<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:speed_limit:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -801,12 +774,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 			<label text="Not in following cities: Karlsruhe" de.text="Nicht in folgenden Städten: Karlsruhe" />
 			<space />
-			<key key="railway"
-				value="signal" />
-			<text key="ref"
-				text="Signal ref"
-				de.text="Signalbezeichnung"
-				/>
+			<reference ref="sig_ref" />
 			<check key="railway:signal:switch:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
@@ -850,12 +818,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 			<label text="Crossing Signal (Bü 0/Bü 1)" de.text="Bü-Überwachungssignal (Bü 0/Bü 1)" />
 			<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 			<space />
-			<key key="railway"
-				value="signal" />
-			<text key="ref"
-				text="Signal ref"
-				de.text="Signalbezeichnung"
-				/>
+			<reference ref="sig_ref" />
 			<check key="railway:signal:crossing:deactivated"
 				text="Out of order"
 				de.text="Ungültigkeitskreuz"
@@ -1025,12 +988,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Only in Hamburg" de.text="Nur in Hamburg" />
 				<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:main:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -1099,12 +1057,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Only in Hamburg" de.text="Nur in Hamburg" />
 				<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -1179,12 +1132,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Close doors (A 1), depart (A 2)" de.text="Türen schließen (A 1), Abfahren (A 2)" />
 				<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:departure:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -1345,12 +1293,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Expect Sh 2 (L 2)" de.text="Ankündigungsscheibe zu Schutzhaltsignal Sh2 (L 2)." />
 				<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:minor_distant:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -1418,12 +1361,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.text="Anfangsscheibe (L 4). Ab hier gilt die durch L 1 angekündigte Geschwindigkeit." />
 				<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:speed_limit:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -1580,12 +1518,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Switch Driveup Signal (Wv)" de.text="Weichenvorrücksignal (Wv)" />
 				<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 				<space />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
-				<key key="railway"
-					value="signal" />
+				<reference ref="sig_ref" />
 				<check key="railway:signal:switch:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -1618,12 +1551,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Only in Karlsruhe" de.text="Nur in Karlsruhe" />
 				<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 				<space />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
-				<key key="railway"
-					value="signal" />
+				<reference ref="sig_ref" />
 				<check key="railway:signal:switch:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -1669,12 +1597,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Only on SSB infrastructure (in and around Stuttgart)" de.text="Nur auf SSB-Infrastruktur (in und um Stuttgart)" />
 				<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:main:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -1713,12 +1636,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Only on SSB infrastructure (in and around Stuttgart)" de.text="Nur auf SSB-Infrastruktur (in und um Stuttgart)" />
 				<label de.text="Wird als Punkt auf dem Gleis erfasst." text="Is being mapped as a node on the track." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:combined:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"

--- a/josm-presets/de-signals-bostrab.xml
+++ b/josm-presets/de-signals-bostrab.xml
@@ -12,6 +12,15 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 
 
 <presets xmlns="http://josm.openstreetmap.de/tagging-preset-1.0" author="OpenRailwayMap" version="1.0" shortdescription="OpenRailwayMap BOStrab signals" description="Preset to tag tram signals in Germany">
+	<chunk id="direction_fw_bw">
+		<combo key="railway:signal:direction"
+			text="Direction"
+			de.text="Anzeigerichtung"
+			values="forward,backward"
+			display_values="in direction of OSM way,against direction of OSM way"
+			de.display_values="In Wegrichtung,Entgegen Wegrichtung"
+			/>
+	</chunk>
 	<group name="OpenRailwayMap BOStrab-Signale" icon="signals.png">
 		<item name="Main signal (Fahrsignal/F) for on-sight running trams" de.name="Fahrsignal (F)" icon="de/bostrab/f0-32.png" type="node">
 			<label de.text="Main signal (F 0/F 1) for on-sight running trams, colloquially also known as Balkensignal" 
@@ -35,13 +44,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 				display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="in direction of OSM way,in opposite direction of OSM way"
-				de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:main"
 				value="DE-BOStrab:f" />
@@ -54,7 +57,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="F 0 (Halt);F 1 (Fahrt geradeaus);F 2 (Fahrt rechts);F 3 (Fahrt links) ;F 4 (Halt zu erwarten);F 5 (StVO-Abbiegeregeln beachten)"
 				/>
 			<key key="railway:signal:main:form"
-				value="light"/>
+				value="light" />
 			<combo key="railway:signal:main:height"
 				text="Signal height"
 				de.text="Signalbauform"
@@ -86,13 +89,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:main"
 					value="DE-BOStrab:h" />
@@ -105,7 +102,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="H 0 (Halt);H 1 (Fahrt);H 2 (Fahrt mit Geschwindigkeitsbeschränkung)"
 					/>
 				<key key="railway:signal:main:form"
-					value="light"/>
+					value="light" />
 				<combo key="railway:signal:main:height"
 					text="Signal height"
 					de.text="Signalbauform"
@@ -136,13 +133,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:combined"
 					value="DE-BOStrab:h" />
@@ -155,7 +146,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="H 0 (Halt);H 1 (Fahrt);H 2 (Fahrt mit Geschwindigkeitsbeschränkung)"
 					/>
 				<key key="railway:signal:combined:form"
-					value="light"/>
+					value="light" />
 				<combo key="railway:signal:combined:height"
 					text="Signal height"
 					de.text="Signalbauform"
@@ -186,13 +177,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:distant"
 					value="DE-BOStrab:v" />
@@ -205,7 +190,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="V 0 (Halt erwarten);V 1 (Fahrt erwarten);V 2 (Langsamfahrt erwarten)"
 					/>
 				<key key="railway:signal:distant:form"
-					value="light"/>
+					value="light" />
 				<combo key="railway:signal:distant:height"
 					text="Signal height"
 					de.text="Signalbauform"
@@ -236,13 +221,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 				display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="in direction of OSM way,in opposite direction of OSM way"
-				de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<key key="railway:signal:departure"
 				value="DE-BOStrab:a1" />
 			<combo key="railway:signal:departure:states"
@@ -272,13 +251,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:speed_limit_distant"
 					value="DE-BOStrab:g1a" />
@@ -326,13 +299,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:speed_limit_distant"
 					value="DE-BOStrab:g1b" />
@@ -371,13 +338,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:speed_limit"
 					value="DE-BOStrab:g2a" />
@@ -425,13 +386,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:speed_limit"
 					value="DE-BOStrab:g2b" />
@@ -470,13 +425,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:speed_limit"
 					value="DE-BOStrab:g3" />
@@ -504,13 +453,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:speed_limit"
 					value="DE-BOStrab:g4" />
@@ -543,13 +486,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung,im Gleis"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary,in track"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:minor"
 					value="DE-BOStrab:sh1" />
@@ -574,13 +511,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung,im Gleis"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary,in track"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:minor"
 					value="DE-BOStrab:sh2" />
@@ -606,13 +537,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung,im Gleis"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary,in track"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:minor"
 					value="DE-BOStrab:sh3d" />
@@ -636,13 +561,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:ring"
 					value="DE-BOStrab:sh4" />
 				<key key="railway:signal:ring:form"
@@ -665,13 +584,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung,im Gleis"
 					display_values="left in direction of OSM way,right in direction of OSM way,catenary,in track"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:stop"
 					value="DE-BOStrab:sh7" />
 				<key key="railway:signal:stop:form"
@@ -707,13 +620,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 					display_values="left,right,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:electricity"
 					value="DE-BOStrab:st3" />
 				<combo key="railway:signal:electricity:height"
@@ -724,7 +631,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Mastbauform,Zwergsignal"
 					/>
 				<key key="railway:signal:electricity:type"
-					value="power_off"/>
+					value="power_off" />
 				<key key="railway:signal:electricity:form"
 					value="sign" />
 			</item>
@@ -745,13 +652,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 					display_values="left,right,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:electricity"
 					value="DE-BOStrab:st4" />
 				<combo key="railway:signal:electricity:height"
@@ -762,7 +663,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Mastbauform,Zwergsignal"
 					/>
 				<key key="railway:signal:electricity:type"
-					value="power_on"/>
+					value="power_on" />
 				<key key="railway:signal:electricity:form"
 					value="sign" />
 			</item>
@@ -783,13 +684,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 					display_values="left,right,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:electricity"
 					value="DE-BOStrab:st5" />
 				<combo key="railway:signal:electricity:height"
@@ -800,7 +695,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Mastbauform,Zwergsignal"
 					/>
 				<key key="railway:signal:electricity:type"
-					value="pantograph_down"/>
+					value="pantograph_down" />
 				<key key="railway:signal:electricity:form"
 					value="sign" />
 			</item>
@@ -821,13 +716,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 					display_values="left,right,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:electricity"
 					value="DE-BOStrab:st7" />
 				<combo key="railway:signal:electricity:height"
@@ -838,7 +727,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Mastbauform,Zwergsignal"
 					/>
 				<key key="railway:signal:electricity:type"
-					value="pantograph_up"/>
+					value="pantograph_up" />
 				<key key="railway:signal:electricity:form"
 					value="sign" />
 			</item>
@@ -859,13 +748,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 					display_values="left,right,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:electricity"
 					value="DE-BOStrab:st7" />
 				<combo key="railway:signal:electricity:height"
@@ -876,7 +759,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Mastbauform,Zwergsignal"
 					/>
 				<key key="railway:signal:electricity:type"
-					value="power_off_shortly"/>
+					value="power_off_shortly" />
 				<key key="railway:signal:electricity:form"
 					value="sign" />
 			</item>
@@ -897,13 +780,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 					display_values="left,right,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:electricity"
 					value="DE-BOStrab:st8" />
 				<combo key="railway:signal:electricity:height"
@@ -914,7 +791,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Mastbauform,Zwergsignal"
 					/>
 				<key key="railway:signal:electricity:type"
-					value="end_of_catenary"/>
+					value="end_of_catenary" />
 				<key key="railway:signal:electricity:form"
 					value="sign" />
 			</item>
@@ -941,13 +818,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung,Signalbrücke"
 				display_values="left,right,catenary,bridge"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="in direction of OSM way,in opposite direction of OSM way"
-				de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:switch"
 				value="DE-BOStrab:w" />
@@ -996,13 +867,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				display_values="left in direction of OSM way,right in direction of OSM way,bridge"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="in direction of OSM way,in opposite direction of OSM way"
-				de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:crossing"
 				value="DE-BOStrab:bü" />
@@ -1036,13 +901,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				display_values="left in direction of OSM way,right in direction of OSM way,bridge"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="in direction of OSM way,in opposite direction of OSM way"
-				de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<space />
 			<key key="railway:signal:crossing_distant"
 				value="DE-BOStrab:bü2" />
@@ -1067,13 +926,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				display_values="left in direction of OSM way,right in direction of OSM way,bridge"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="in direction of OSM way,in opposite direction of OSM way"
-				de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<key key="railway:signal:train_protection"
 				value="DE-BOStrab:so1" />
 			<key key="railway:signal:train_protection:type"
@@ -1098,13 +951,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 				display_values="left in direction of OSM way,right in direction of OSM way,bridge"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="in direction of OSM way,in opposite direction of OSM way"
-				de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<key key="railway:signal:train_protection"
 				value="DE-BOStrab:so2" />
 			<key key="railway:signal:train_protection:type"
@@ -1129,13 +976,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 				display_values="left,right,catenary"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				display_values="in direction of OSM way,in opposite direction of OSM way"
-				de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-				/>
+			<reference ref="direction_fw_bw" />
 			<key key="railway:signal:passing"
 				value="DE-BOStrab:so5" />
 			<key key="railway:signal:passing:type"
@@ -1165,13 +1006,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 				display_values="left,right,catenary"
 				/>
-			<combo key="railway:signal:direction"
-				text="Direction"
-				de.text="Anzeigerichtung"
-				values="forward,backward"
-				de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-				display_values="in direction of OSM way,in opposite direction of OSM way"
-				/>
+			<reference ref="direction_fw_bw" />
 			<key key="railway:signal:passing"
 				value="DE-BOStrab:so6" />
 			<key key="railway:signal:passing:type"
@@ -1207,13 +1042,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:main"
 					value="DE-HHA:h" />
@@ -1226,7 +1055,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Halt (rot);Warten und Weiterfahrt auf Sicht (gelb);Fahrt (grün);Vorsichtig vorrücken zum nächsten Hauptsignal (blinkender Pfeil);Vorrücken in besetztes Gleis (gelbes V)"
 					/>
 				<key key="railway:signal:main:form"
-					value="light"/>
+					value="light" />
 				<combo key="railway:signal:main:height"
 					text="Signal height"
 					de.text="Signalbauform"
@@ -1251,13 +1080,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:shunting"
 					value="DE-HHA:h5" />
@@ -1293,13 +1116,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:distant"
 					value="DE-HHA:v" />
@@ -1312,7 +1129,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="V 1 (Halt erwarten);V 2 (Fahrt erwarten);V 3 (Langsamfahrt erwarten)"
 					/>
 				<key key="railway:signal:distant:form"
-					value="light"/>
+					value="light" />
 				<combo key="railway:signal:distant:height"
 					text="Signal height"
 					de.text="Signalbauform"
@@ -1338,13 +1155,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:speed_limit_distant"
 					value="DE-HHA:v" />
@@ -1385,13 +1196,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:departure"
 					value="DE-HHA:a1" />
 				<combo key="railway:signal:departure:states"
@@ -1420,13 +1225,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 					display_values="left,right,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:electricity"
 					value="DE-HHA:s1" />
 				<combo key="railway:signal:electricity:height"
@@ -1437,7 +1236,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Mastbauform,Zwergsignal"
 					/>
 				<key key="railway:signal:electricity:type"
-					value="power_off"/>
+					value="power_off" />
 				<key key="railway:signal:electricity:form"
 					value="sign" />
 			</item>
@@ -1458,13 +1257,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung"
 					display_values="left,right,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:electricity"
 					value="DE-HHA:s2" />
 				<combo key="railway:signal:electricity:height"
@@ -1497,13 +1290,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung,im Gleis"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary,in track"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:minor"
 					value="DE-HHA:sh3" />
@@ -1527,13 +1314,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:speed_limit_distant"
 					value="DE-HHA:l1" />
@@ -1581,13 +1362,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:minor_distant"
 					value="DE-HHA:l2" />
@@ -1618,13 +1393,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:speed_limit"
 					value="DE-HHA:l3" />
@@ -1666,13 +1435,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:speed_limit"
 					value="DE-HHA:l4" />
@@ -1709,13 +1472,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<text key="railway:signal:speed_limit:caption"
 					text="Number of cars (at L 6 sign)"
@@ -1745,13 +1502,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung,im Gleis"
 					display_values="left in direction of OSM way,right in direction of OSM way,catenary,in track"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:stop"
 					value="DE-HHA:so3" />
 				<key key="railway:signal:stop:form"
@@ -1785,13 +1536,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						display_values="left in direction of OSM way,right in direction of OSM way,bridge"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,in opposite direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<key key="railway:signal:wrong_road"
 						value="DE-HHA:so4" />
 					<combo key="railway:signal:wrong_road:form"
@@ -1818,13 +1563,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						display_values="left in direction of OSM way,right in direction of OSM way,bridge"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,in opposite direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:route"
 						value="DE-HHA:so7" />
@@ -1858,13 +1597,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung,Signalbrücke"
 					display_values="left,right,catenary,bridge"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:switch"
 					value="DE-VBK:wv" />
@@ -1902,13 +1635,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Oberleitung,Signalbrücke"
 					display_values="left,right,catenary,bridge"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:switch"
 					value="DE-VBK:w" />
@@ -1959,13 +1686,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:main"
 					value="DE-BOStrab:h" />
@@ -1978,7 +1699,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="H 0 (Halt, rot);H 1 (Warten und Weiterfahrt auf Sicht, gelb);H 2 (Fahrt, grün);H 5 (Nachfahren, gelbes N);H 6 (Versuchsbetrieb, gelbes A)"
 					/>
 				<key key="railway:signal:main:form"
-					value="light"/>
+					value="light" />
 				<combo key="railway:signal:main:height"
 					text="Signal height"
 					de.text="Signalbauform"
@@ -2009,13 +1730,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Oberleitung"
 					display_values="left in direction of OSM way,right in direction of OSM way,bridge,catenary"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,in opposite direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:combined"
 					value="DE-BOStrab:h" />
@@ -2028,7 +1743,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="H 0 (Halt, rot);H 1 (Warten und Weiterfahrt auf Sicht, gelb);H 2 (Fahrt, grün);H 3 (Vorsicht, gelbes V);H 4 (Fahrt + Halt erwarten, gelb-grün);H 5 (Nachfahren, gelbes N);H 6 (Versuchsbetrieb, gelbes A)"
 					/>
 				<key key="railway:signal:combined:form"
-					value="light"/>
+					value="light" />
 				<combo key="railway:signal:combined:height"
 					text="Signal height"
 					de.text="Signalbauform"

--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -12,6 +12,24 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 
 
 <presets xmlns="http://josm.openstreetmap.de/tagging-preset-1.0" author="OpenRailwayMap" version="1.0" shortdescription="OpenRailwayMap Signale DE ESO" description="Preset to tag German railway signals">
+	<chunk id="direction_fw_bw">
+		<combo key="railway:signal:direction"
+			text="Direction"
+			de.text="Anzeigerichtung"
+			values="forward,backward"
+			display_values="in direction of OSM way,against direction of OSM way"
+			de.display_values="In Wegrichtung,Entgegen Wegrichtung"
+			/>
+	</chunk>
+	<chunk id="direction_fw_bw_b">
+		<combo key="railway:signal:direction"
+			text="Direction"
+			de.text="Anzeigerichtung"
+			values="forward,backward,both"
+			display_values="in direction of OSM way,against direction of OSM way,both directions"
+			de.display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
+			/>
+	</chunk>
 	<group name="OpenRailwayMap Signals Germany ESO" de.name="OpenRailwayMap Signale DE ESO" icon="signals.png">
 			<group name="Ks Signals" de.name="Ks-Signale" icon="de/ks-combined-32.png">
 				<item name="Ks Distant Signal" de.name="Ks-Vorsignal" icon="de/ks-distant-32.png" type="node">
@@ -35,13 +53,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:distant"
 						value="DE-ESO:ks" />
@@ -96,13 +108,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:combined"
 						value="DE-ESO:ks" />
@@ -174,13 +180,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:main"
 						value="DE-ESO:ks" />
@@ -246,13 +246,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="left,right,on a bridge over the tracks"
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,against direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:combined"
 					value="DE-ESO:sv" />
@@ -324,13 +318,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:combined"
 						value="DE-ESO:hl" />
@@ -394,13 +382,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:main"
 						value="DE-ESO:hl" />
@@ -464,13 +446,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:distant"
 						value="DE-ESO:hl" />
@@ -517,13 +493,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:combined"
 						value="DE-ESO:sk" />
@@ -590,13 +560,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:main"
 						value="DE-ESO:sk" />
@@ -661,13 +625,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:distant"
 						value="DE-ESO:sk" />
@@ -716,13 +674,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:main"
 						value="DE-ESO:hp" />
@@ -789,13 +741,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:main"
 						value="DE-ESO:hp" />
@@ -863,13 +809,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:distant"
 						value="DE-ESO:vr" />
@@ -926,13 +866,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:distant"
 						value="DE-ESO:vr" />
@@ -992,13 +926,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="left,right,on a bridge over the tracks"
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,against direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<text key="railway:position:exact"
 					text="Exact position if signal is mounted at the left track (e.g. '13.427')"
 					de.text="Standortangabe an Trapeztafeln im Gegengleis (z. B. '13.427')"
@@ -1035,13 +963,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="left,right,on a bridge over the tracks"
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,against direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<combo key="railway:signal:distant"
 					text="Type"
@@ -1080,13 +1002,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="left,right,on a bridge over the tracks"
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,against direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:distant"
 					value="DE-ESO:so106" />
@@ -1112,13 +1028,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<combo key="railway:signal:crossing"
 						text="Exact type"
@@ -1160,13 +1070,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:crossing_distant"
 						value="DE-ESO:bü2" />
@@ -1193,12 +1097,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:crossing_distant"
 						value="DE-ESO:so15" />
@@ -1227,13 +1126,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<key key="railway:signal:crossing_distant"
 						value="DE-ESO:bü3"
 						match="keyvalue!" />
@@ -1287,13 +1180,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<combo key="railway:signal:whistle"
 						text="Exact type"
@@ -1331,13 +1218,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<key key="railway:signal:ring"
 						value="DE-ESO:bü5" />
 					<key key="railway:signal:ring:form"
@@ -1363,13 +1244,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<key key="railway:signal:crossing_info"
 						value="DE-ESO:bü-kennzeichentafel" />
 					<key key="railway:signal:crossing_info:form"
@@ -1406,13 +1281,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<key key="railway:signal:crossing_hint"
 						value="DE-ESO:bü-ankündetafel" />
 					<key key="railway:signal:crossing_hint:form"
@@ -1456,13 +1325,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks,in the track/at the buffer stop"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,Gleismitte/am Prellbock"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:minor"
 						value="DE-ESO:sh" />
@@ -1505,12 +1368,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="left,right,in_track"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Gleismitte/am Prellbock"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward,both"
-						display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-						/>
+					<reference ref="direction_fw_bw_b" />
 					<space />
 					<key key="railway:signal:minor"
 						value="DE-ESO:sh2" />
@@ -1540,13 +1398,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:minor_distant"
 						value="DE-ESO:dr:sh3" />
@@ -1578,13 +1430,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:shunting"
 						value="DE-ESO:ra10" />
@@ -1618,13 +1464,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<combo key="railway:signal:shunting"
 						text="Type of signal"
@@ -1671,13 +1511,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="left,right"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:humping"
 						value="DE-ESO:ra" />
@@ -1725,12 +1559,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						values="left,right,bridge"
 						display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<key key="railway:signal:shunting"
 						value="DE-ESO:zs103" />
 					<key key="railway:signal:shunting:form"
@@ -1755,13 +1584,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:route"
 						value="DE-ESO:zs2" />
@@ -1789,13 +1612,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:route_distant"
 						value="DE-ESO:zs2v" />
@@ -1824,13 +1641,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:speed_limit"
 						value="DE-ESO:zs3" />
@@ -1872,13 +1683,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:speed_limit_distant"
 						value="DE-ESO:zs3v" />
@@ -1920,13 +1725,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:speed_limit"
 						value="DE-ESO:db:zs10" />
@@ -1964,13 +1763,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<combo key="railway:signal:wrong_road" text="Type" de.text="Typ" match="keyvalue!">
 		         	<list_entry value="DE-ESO:db:zs6" display_value="Zs 6 DB" short_description="Gegengleisanzeiger Zs 6 (ex-DB)" />
@@ -2000,13 +1793,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<combo key="railway:signal:wrong_road" text="Type" de.text="Typ" match="keyvalue!">
 						<list_entry value="DE-ESO:db:zs8" display_value="Zs 8 DB" short_description="Left-Track Order Signal Zs 8 (ex-DB)" de.short_description="Falschfahrt-Auftragssignal Zs 8 (ex-DB)" />
@@ -2037,13 +1824,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<combo key="railway:signal:short_route"
 						text="Type of signal"
@@ -2085,13 +1866,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<combo key="railway:signal:speed_limit" text="Type of signal" de.text="Signaltyp" match="keyvalue!">
 						<list_entry value="DE-ESO:lf7" display_value="Lf 7" short_description="Permanent Speed Restriction" de.short_description="Geschwindigkeitssignal" />
@@ -2141,13 +1916,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<combo key="railway:signal:speed_limit_distant" text="Type of signal" de.text="Signaltyp" match="keyvalue!">
 						<list_entry value="DE-ESO:lf6" display_value="Lf 6" short_description="advance warning indicator" de.short_description="Geschwindigkeits-Ankündesignal Lf 6" />
@@ -2195,13 +1964,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,against direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:resetting_switch"
 					value="DE-ESO:ne13" />
@@ -2233,13 +1996,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,against direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<key key="railway:signal:resetting_switch_distant"
 					value="DE-ESO:ne12" />
@@ -2270,13 +2027,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,against direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<combo key="railway:signal:expected_position"
 					text="Side of track where the signal would be mounted usually"
 					de.text="Gleisseite, auf der man das Signal normalerweise erwarten würde"
@@ -2308,13 +2059,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,against direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:stop"
 					value="DE-ESO:ne5" />
 				<key key="railway:signal:stop:form"
@@ -2349,13 +2094,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,against direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:stop_demand"
 					value="DE-ESO:ne5" />
 				<key key="railway:signal:stop_demand:form"
@@ -2384,13 +2123,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,against direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:station_distant"
 					value="DE-ESO:ne6" />
 				<key key="railway:signal:station_distant:form"
@@ -2412,13 +2145,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,against direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<key key="railway:signal:snowplow"
 					value="DE-ESO:ne7" />
 				<key key="railway:signal:snowplow:form"
@@ -2458,13 +2185,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="left,right,on a bridge over the tracks,overhead (at catenary level)"
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke,in der Oberleitung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,against direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<check key="railway:signal:catenary_mast"
 					text="On catenary mast"
 					de.text="Am Oberleitungsmast"
@@ -2493,13 +2214,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="left,right,overhead (at catenary level)"
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,in der Oberleitung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,against direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<space />
 				<combo key="railway:signal:electricity"
 					text="Exact type"
@@ -2557,13 +2272,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:helper_engine"
 						value="DE-ESO:ts" />
@@ -2600,13 +2309,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 						display_values="left,right,on a bridge over the tracks"
 						de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 						/>
-					<combo key="railway:signal:direction"
-						text="Direction"
-						de.text="Anzeigerichtung"
-						values="forward,backward"
-						display_values="in direction of OSM way,against direction of OSM way"
-						de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-						/>
+					<reference ref="direction_fw_bw" />
 					<space />
 					<key key="railway:signal:helper_engine"
 						value="DE-ESO:ts" />
@@ -2645,12 +2348,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="left,right,on a bridge over the tracks"
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward,both"
-					display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-					/>
+				<reference ref="direction_fw_bw_b" />
 				<space />
 				<key key="railway:signal:main_repeated"
 					value="DE-ESO:fahrtanzeiger" />
@@ -2674,12 +2372,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="left,right,on a bridge over the tracks"
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward,both"
-					display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-					/>
+				<reference ref="direction_fw_bw_b" />
 				<key key="railway:signal:departure"
 					value="DE-ESO:zp" />
 				<multiselect key="railway:signal:departure:states"
@@ -2710,12 +2403,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					display_values="left,right,on a bridge over the tracks"
 					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung,Signalbrücke"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward,both"
-					display_values="In Wegrichtung,Entgegen Wegrichtung,Beide Richtungen"
-					/>
+				<reference ref="direction_fw_bw_b" />
 				<key key="railway:signal:brake_test"
 					value="DE-ESO:zp" />
 				<key key="railway:signal:brake_test:form"
@@ -2743,13 +2431,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,against direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<check key="railway:signal:catenary_mast"
 					text="On catenary mast"
 					de.text="Am Oberleitungsmast"
@@ -2781,13 +2463,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					values="left,right"
 					display_values="Links von Wegrichtung,Rechts von Wegrichtung"
 					/>
-				<combo key="railway:signal:direction"
-					text="Direction"
-					de.text="Anzeigerichtung"
-					values="forward,backward"
-					display_values="in direction of OSM way,against direction of OSM way"
-					de.display_values="In Wegrichtung,Entgegen Wegrichtung"
-					/>
+				<reference ref="direction_fw_bw" />
 				<check key="railway:signal:catenary_mast"
 					text="On catenary mast"
 					de.text="Am Oberleitungsmast"

--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -12,6 +12,14 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 
 
 <presets xmlns="http://josm.openstreetmap.de/tagging-preset-1.0" author="OpenRailwayMap" version="1.0" shortdescription="OpenRailwayMap Signale DE ESO" description="Preset to tag German railway signals">
+	<chunk id="sig_ref">
+		<key key="railway"
+			value="signal" />
+		<text key="ref"
+			text="Signal ref"
+			de.text="Signalbezeichnung"
+			/>
+	</chunk>
 	<chunk id="direction_fw_bw">
 		<combo key="railway:signal:direction"
 			text="Direction"
@@ -36,12 +44,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Ks Distant Signal" de.text="Ks-Vorsignal" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -91,12 +94,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Ks Combined Signal" de.text="Ks-Mehrabschnittssignal" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:combined:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -163,12 +161,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Ks Main Signal" de.text="Ks-Hauptsignal" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -229,12 +222,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Sv Signal" de.text="Sv-Signal" />
 				<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:combined:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -301,12 +289,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Hl Combined Signal" de.text="Hl-Kombinationssignal" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:combined:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -365,12 +348,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Hl Main Signal" de.text="Hl-Hauptsignal" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -429,12 +407,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Hl Distant Signal" de.text="Hl-Vorsignal" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -476,12 +449,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Sk Combined Signal" de.text="Sk-Kombinationssignal" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:combined:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -543,12 +511,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Sk Main Signal" de.text="Sk-Hauptsignal" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -608,12 +571,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Sk Distant Signal" de.text="Sk-Vorsignal" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -657,12 +615,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Hp Semaphore Main Signal" de.text="Hp-Form-Hauptsignal" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -724,12 +677,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Hp Light Signal" de.text="Hp-Licht-Hauptsignal" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:main:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -792,12 +740,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Vr Semaphore Distant Signal" de.text="Vr-Form-Vorsignal" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -849,12 +792,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Vr Distant Light Signal" de.text="Vr-Licht-Vorsignal" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -1308,12 +1246,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Shunting Stop Signal (Sh 0/Sh 1)" de.text="Schutzhaltsignal  (Sh 0/Sh 1)" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:minor:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -1381,12 +1314,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Expect Sh 2 Board" de.text="Wärtervorscheibe" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:minor_distant:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -1448,12 +1376,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					<label text="Rangierhaltsignal" />
 					<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 					<space />
-					<key key="railway"
-						value="signal" />
-					<text key="ref"
-						text="Signal ref"
-						de.text="Signalbezeichnung"
-						/>
+					<reference ref="sig_ref" />
 					<check key="railway:signal:shunting:deactivated"
 						text="Out of order"
 						de.text="Ungültigkeitskreuz"
@@ -2168,12 +2091,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="ETCS Stop Marker (Ne 14)" de.text="ETCS-Halt-Tafel (Ne 14), auch bekannt als ETCS Stop Marker" />
 				<label text="Wird als Punkt auf dem Gleis erfasst. Steht am Hauptsignal oder virtuellem Signal (Level 2 ohne Signale)." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichner"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:train_protection:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"
@@ -2331,12 +2249,7 @@ See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 				<label text="Proceed Indicatgor" de.text="Fahrtanzeiger" />
 				<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
 				<space />
-				<key key="railway"
-					value="signal" />
-				<text key="ref"
-					text="Signal ref"
-					de.text="Signalbezeichnung"
-					/>
+				<reference ref="sig_ref" />
 				<check key="railway:signal:main_repeated:deactivated"
 					text="Out of order"
 					de.text="Ungültigkeitskreuz"


### PR DESCRIPTION
This save a lot of duplication and fixes a few places that were out of sync:
 - German strings in display_values
 - display_values with trailing ',' so there were more entries than in values