### PR TITLE
Apache timestamp file

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -151,11 +151,14 @@ $ chmod 600 ~/.pgpass
 ```
 
  API is served by api.js which listens on port 9002, therefore we forward incoming request to this port.
+ Create a ProxyPass exception and Alias for the timestamp file, so that it is accessible under http://api.openrailwaymap.org/timestamp.
  Vhost configuration of the API (`api.openrailwaymap.org.conf`) looks like this:
 
 ```ApacheConf
 <VirtualHost *:80>
     ServerName api.openrailwaymap.org
+    ProxyPass /timestamp !
+    Alias "/timestamp" "/var/www/html/OpenRailwayMap/import/timestamp"
     ProxyPreserveHost On
     ProxyPass / http://localhost:9002/
     ProxyPassReverse / http://localhost:9002/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -159,6 +159,7 @@ $ chmod 600 ~/.pgpass
     ServerName api.openrailwaymap.org
     ProxyPass /timestamp !
     Alias "/timestamp" "/var/www/html/OpenRailwayMap/import/timestamp"
+    Header add Access-Control-Allow-Origin "*"
     ProxyPreserveHost On
     ProxyPass / http://localhost:9002/
     ProxyPassReverse / http://localhost:9002/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -157,12 +157,18 @@ $ chmod 600 ~/.pgpass
 ```ApacheConf
 <VirtualHost *:80>
     ServerName api.openrailwaymap.org
+
     ProxyPass /timestamp !
     Alias "/timestamp" "/var/www/html/OpenRailwayMap/import/timestamp"
     Header add Access-Control-Allow-Origin "*"
+    <location /timestamp>
+        ForceType text/plain
+    </location>
+
     ProxyPreserveHost On
     ProxyPass / http://localhost:9002/
     ProxyPassReverse / http://localhost:9002/
+
     ErrorLog /var/log/apache2/api.openrailwaymap.org.error.log
     LogLevel warn
     CustomLog /var/log/apache2/api.openrailwaymap.org.access.log combined

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -160,7 +160,7 @@ $ chmod 600 ~/.pgpass
 
     ProxyPass /timestamp !
     Alias "/timestamp" "/var/www/html/OpenRailwayMap/import/timestamp"
-    Header add Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Origin "*"
     <location /timestamp>
         ForceType text/plain
     </location>


### PR DESCRIPTION
Modifies the Apache config so that the timestamp file is served directly as plain text.