### PR TITLE
Use Kothic to draw the legend

### DIFF
--- a/api/legend-generator.php
+++ b/api/legend-generator.php
@@ -24,56 +24,77 @@
 		<title><?=$appname?></title>
 		<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 		<link rel="stylesheet" type="text/css" href="../css/legend.css" />
+		<script type="text/javascript" src="../renderer/kothic/kothic.js"></script>
+		<script type="text/javascript" src="../renderer/kothic/renderer/path.js"></script>
+		<script type="text/javascript" src="../renderer/kothic/renderer/line.js"></script>
+		<script type="text/javascript" src="../renderer/kothic/renderer/polygon.js"></script>
+		<script type="text/javascript" src="../renderer/kothic/renderer/shields.js"></script>
+		<script type="text/javascript" src="../renderer/kothic/renderer/texticons.js"></script>
+		<script type="text/javascript" src="../renderer/kothic/renderer/text.js"></script>
+		<script type="text/javascript" src="../renderer/kothic/style/mapcss.js"></script>
+		<script type="text/javascript" src="../renderer/kothic/style/style.js"></script>
+		<script type="text/javascript" src="../renderer/kothic/utils/collisions.js"></script>
+		<script type="text/javascript" src="../renderer/kothic/utils/geom.js"></script>
+		<script type="text/javascript" src="../renderer/kothic/utils/rbush.js"></script>
+		<script type="text/javascript" src="../styles/<?php echo $_GET['style']; ?>.js"></script>
+		<script type="text/javascript" src="../js/functions.js"></script>
+		</script>
 	</head>
-	<body>
-		<?php
-			$output = "";
+	<?php
+		$output = "";
 
-			function writeLine($payload, $caption)
-			{
-				return '<tr><td>' . $payload . '</td><td>' . htmlspecialchars($caption) . "</td></tr>\n";
+		function writeLine($index, $height, $payload, $caption)
+		{
+			$line = "\t\t\t<tr><td";
+
+			if ($height) {
+				$line .= ' style="height: ' . $height . 'px;"';
+			} else {
+				$height = '16';
 			}
 
-			if (file_exists($filename))
-			{
-				$legend = json_decode(file_get_contents($filename), true);
+			return $line . '><canvas width="80" height="' . $height . '" id="legend-' . $index
+					. '" data-geojson=' . "'" . $payload
+					. "'></canvas></td>\n\t\t\t\t<td>"
+					. htmlspecialchars(_($caption)) . "</td></tr>\n";
+		}
 
-				foreach ($legend['mapfeatures'] as $feature)
+		if (file_exists($filename))
+		{
+			$legend = json_decode(file_get_contents($filename), true);
+			$cnt = -1;
+
+			foreach ($legend['mapfeatures'] as $feature)
+			{
+				if ($zoom >= $feature['minzoom'] && (!isset($feature['maxzoom']) || $zoom <= $feature['maxzoom']) && (isset($feature['features']) || isset($feature['heading'])))
 				{
-					if ($zoom >= $feature['minzoom'] && (!isset($feature['maxzoom']) || $zoom <= $feature['maxzoom']))
-					{
-						if (isset($feature['heading'])) {
-							$output .= '<tr><td colspan="2" class="section">' . htmlspecialchars(_($feature['heading'])) . "</td></tr>\n";
-						} else if (isset($feature['replace'])) {
-							foreach ($feature['replace'] as $replace) {
-								$caption = str_replace(array_keys($replace), array_values($replace), _($feature['caption']));
-								if (isset($feature['symbol']) && $feature['symbol'] != null)
-									$payload = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1">' . str_replace(array_keys($replace), array_values($replace), $feature['symbol']) . '</svg>';
-								else
-									$payload = '<img src="../styles/' . str_replace(array_keys($replace), array_values($replace), $feature['icon']) . '" />';
-								$output .= writeLine($payload, $caption);
-							}
-						} else {
-							if (isset($feature['symbol']) && $feature['symbol'] != null)
-								$payload = '<svg xmlns="http://www.w3.org/2000/svg" version="1.1">' . $feature['symbol'] . '</svg>';
-							else
-								$payload = '<img src="../styles/' . $feature['icon'] . '" />';
-							$output .= writeLine($payload, _($feature['caption']));
+					$lineheight = isset($feature['lineheight']) ? $feature['lineheight'] : '';
+
+					if (isset($feature['heading'])) {
+						$output .= "\t\t\t<tr><td colspan=\"2\" class=\"section\">" . htmlspecialchars(_($feature['heading'])) . "</td></tr>\n";
+					} else if (isset($feature['replace'])) {
+						foreach ($feature['replace'] as $replace) {
+							$caption = str_replace(array_keys($replace), array_values($replace), _($feature['caption']));
+							$payload = str_replace(array_keys($replace), array_values($replace), json_encode($feature['features']));
+							$output .= writeLine(++$cnt, $lineheight, $payload, $caption);
 						}
+					} else {
+						$output .= writeLine(++$cnt, $lineheight, json_encode($feature['features']), _($feature['caption']));
 					}
 				}
-
-				// if no features are rendered in this zoom level, show message
-				if ($output == "")
-					$output = '<p>' . _('Nothing to see in this zoom level. Please zoom in.') . "</p>\n";
-				else
-					$output = "\t\t<table>\n" . $output . "\t\t</table>\n";
 			}
-			// if legend cannot be loaded
-			else
-				$output = '<p>' . _('Legend not available for this style.') . "</p>\n";
 
-			echo $output;
-		?>
+			// if no features are rendered in this zoom level, show message
+			if ($output == "")
+				$output = "<body>\n<p>" . _('Nothing to see in this zoom level. Please zoom in.') . "</p>\n";
+			else
+				$output = "<body onload=\"drawLegendIcons($cnt, $zoom, '" . $_GET['style'] . "')\">\n\t\t<table>\n" . $output . "\t\t</table>\n";
+		}
+		// if legend cannot be loaded
+		else
+			$output = "<body>\n\t\t<p>" . _('Legend not available for this style.') . "</p>\n";
+
+		echo $output;
+	?>
 	</body>
 </html>

--- a/css/legend.css
+++ b/css/legend.css
@@ -36,8 +36,8 @@ td.section {
 	padding-top: 1em;
 }
 
-svg
+canvas
 {
-	height: 16px;
-	width: 80px;
+	padding: 0;
+	margin: 0;
 }

--- a/js/functions.js
+++ b/js/functions.js
@@ -40,6 +40,24 @@ function updateLegend(id, style)
 	gEBI(id).src = window.openrailwaymap.root+"api/legend-generator.php?zoom="+map.getZoom()+"&style="+style+"&lang="+params['lang'];
 }
 
+// draws the legend entries on canvas
+function drawLegendIcons(cnt, zoom, st) {
+	MapCSS.preloadSpriteImage(st, '../styles/' + st + '.png');
+	var style = { styles: [st] };
+	for (i = 0; i <= cnt; i++) {
+		var element = document.getElementById('legend-' + i);
+		var data = element.dataset.geojson;
+
+		if (!data) {
+			console.debug("found", 'legend-' + i, " but element has no GeoJSON data");
+			continue;
+		}
+
+		data = '{"features":' + data + ',"granularity":100}';
+
+		Kothic.render(element, JSON.parse(data), zoom, style);
+	}
+}
 
 // renews the permalink url after zooming, changing style or dragging the map
 function updatePermalink(style)

--- a/locales/ca_ES/LC_MESSAGES/messages.po
+++ b/locales/ca_ES/LC_MESSAGES/messages.po
@@ -524,9 +524,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -591,9 +588,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -771,4 +765,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/ca_ES/LC_MESSAGES/messages.po
+++ b/locales/ca_ES/LC_MESSAGES/messages.po
@@ -503,15 +503,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -521,19 +512,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -545,25 +527,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -575,49 +545,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -629,16 +569,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -650,19 +584,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -674,19 +599,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -698,31 +611,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -732,9 +630,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -749,12 +644,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -762,9 +651,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -788,25 +674,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -815,14 +689,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/cs_CZ/LC_MESSAGES/messages.po
+++ b/locales/cs_CZ/LC_MESSAGES/messages.po
@@ -529,9 +529,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -596,9 +593,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -776,4 +770,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/cs_CZ/LC_MESSAGES/messages.po
+++ b/locales/cs_CZ/LC_MESSAGES/messages.po
@@ -508,15 +508,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -526,19 +517,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -550,25 +532,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -580,49 +550,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -634,16 +574,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -655,19 +589,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -679,19 +604,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -703,31 +616,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -737,9 +635,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -754,12 +649,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -767,9 +656,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -793,25 +679,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -820,14 +694,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/da_DK/LC_MESSAGES/messages.po
+++ b/locales/da_DK/LC_MESSAGES/messages.po
@@ -522,9 +522,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -589,9 +586,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -769,4 +763,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/da_DK/LC_MESSAGES/messages.po
+++ b/locales/da_DK/LC_MESSAGES/messages.po
@@ -501,15 +501,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -519,19 +510,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -543,25 +525,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -573,49 +543,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -627,16 +567,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -648,19 +582,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -672,19 +597,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -696,31 +609,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -730,9 +628,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -747,12 +642,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -760,9 +649,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -786,25 +672,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -813,14 +687,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/de_DE/LC_MESSAGES/messages.po
+++ b/locales/de_DE/LC_MESSAGES/messages.po
@@ -561,9 +561,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "shunting signal type Ro"
 msgstr ""
 
@@ -613,9 +610,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -769,4 +763,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/de_DE/LC_MESSAGES/messages.po
+++ b/locales/de_DE/LC_MESSAGES/messages.po
@@ -4,21 +4,22 @@
 # See http://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 #
 # Translators:
-# Alexander Matheisen <alex@matheisen.org>, 2013-2014
+# Alexander Matheisen <alex@matheisen.org>, 2013-2014.
+# Rolf Eike Beer <eike@sf-mail.de>, 2018.
 msgid ""
 msgstr ""
 "Project-Id-Version: OpenRailwayMap\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2013-03-08 12:29+0100\n"
-"PO-Revision-Date: 2017-09-23 19:11+0000\n"
-"Last-Translator: Alexander Matheisen <alex@matheisen.org>\n"
-"Language-Team: German (http://www.transifex.com/rurseekatze/openrailwaymap/language/de/)\n"
+"PO-Revision-Date: 2018-04-15 20:13+0100\n"
+"Last-Translator: Rolf Eike Beer <eike@sf-mail.de>\n"
+"Language-Team: German <kde-i18n-de@kde.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 1.5.4\n"
+"X-Generator: Lokalize 2.0\n"
 "X-Poedit-SourceCharset: utf-8\n"
 
 msgid "More Info"
@@ -544,229 +545,239 @@ msgid "No information about train protection"
 msgstr ""
 
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
-msgstr ""
+msgstr "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 
 msgid "Track usage"
 msgstr ""
 
 msgid "Lf 7 Geschwindigkeitssignal"
-msgstr ""
+msgstr "Lf 7 Geschwindigkeitssignal"
 
 msgid "1.5 – 3kV ="
-msgstr ""
+msgstr "1.5 – 3kV ="
 
 msgid "ETCS under construction"
-msgstr ""
+msgstr "ETCS im Bau"
 
 msgid "3kV ="
-msgstr ""
+msgstr "3kV ="
 
 msgid "shunting signal type Ro"
-msgstr ""
+msgstr "Ro-Sperrsignal"
 
 msgid "Track type"
 msgstr ""
 
 msgid "El 5 \"Bügel an\"-Signal"
-msgstr ""
+msgstr "El 5 \"Bügel an\"-Signal"
 
 msgid "Linienzugbeeinflussung"
-msgstr ""
+msgstr "Linienzugbeeinflussung"
 
 msgid "25kV 50Hz ~"
-msgstr ""
+msgstr "25kV 50Hz ~"
 
 msgid "So 106 Kreuztafel"
-msgstr ""
+msgstr "So 106 Kreuztafel"
 
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
+msgstr "Ra 11 Wartezeichen mit Sh 1"
 
 msgid "Junction, Crossover, Service Station, Site"
-msgstr ""
+msgstr "Abzweig, Überleitstelle, Betriebsbahnhof, Betriebsstelle"
 
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
+msgstr "Hp-Formhauptsignal ohne Angabe der Signalzustände"
 
 msgid "At least 25kV ~"
-msgstr ""
+msgstr "Mindestens 25kV ~"
 
 msgid "minor signal type Lo"
 msgstr ""
 
 msgid "15 – 25kV ~"
-msgstr ""
+msgstr "15 – 25kV ~"
 
 msgid "ETCS"
-msgstr ""
+msgstr "ETCS"
 
 msgid "Blockkennzeichen"
-msgstr ""
+msgstr "Blockkennzeichen"
 
 msgid "Ne 6 Haltepunkttafel"
-msgstr ""
+msgstr "Ne 6 Haltepunkttafel"
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
+msgstr "Ne 1 Trapeztafel"
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
+msgstr "15kV 16⅔Hz ~"
 
-msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
+msgid ""
+"Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
+"Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 
 msgid "Ne 5 Haltetafel"
-msgstr ""
+msgstr "Ne 5 Haltetafel"
 
 msgid "More than 3kV ="
-msgstr ""
+msgstr "Mehr als 3kV ="
 
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
-msgstr ""
+msgstr "Lf 6 Geschwindigkeits­ankündesignal"
 
 msgid "750 – 1000V ="
-msgstr ""
+msgstr "750 – 1000V ="
 
 msgid "Less than 15kV ~"
-msgstr ""
+msgstr "Weniger als 15kV ~"
 
 msgid "1kV ="
-msgstr ""
+msgstr "1kV ="
 
 msgid "1 – 1.5kV ="
-msgstr ""
+msgstr "1 – 1.5kV ="
 
 msgid "block signal type So"
 msgstr ""
 
 msgid "%SPDMIN%-%SPDMAX% km/h"
-msgstr ""
+msgstr "%SPDMIN%-%SPDMAX% km/h"
 
 msgid "1.5kV ="
-msgstr ""
+msgstr "1.5kV ="
 
 msgid "El 2 Einschaltsignal"
-msgstr ""
+msgstr "El 2 Einschaltsignal"
 
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
-msgstr ""
+msgstr "Ra 10 Rangierhalttafel / Verschubhalttafel"
 
 msgid "Zs 10 Endesignal (Tafel)"
-msgstr ""
+msgstr "Zs 10 Endesignal (Tafel)"
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
+msgstr "El 1 Ausschaltsignal"
 
 msgid "Ra 11b Wartezeichen"
-msgstr ""
+msgstr "Ra 11b Wartezeichen"
 
 msgid "El 6 Halt für Fahrzeuge mit gehobenem Stromabnehmer"
-msgstr ""
+msgstr "El 6 Halt für Fahrzeuge mit gehobenem Stromabnehmer"
 
 msgid "Less than 750V ="
-msgstr ""
+msgstr "Wenigse als 750V ="
 
 msgid "Punktförmige Zugbeeinflussung"
-msgstr ""
+msgstr "Punktförmige Zugbeeinflussung"
 
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
+msgstr "El 4 \"Bügel ab\"-Signal"
 
 msgid "750V ="
-msgstr ""
+msgstr "750V ="
 
 msgid "25kV 60Hz ~"
-msgstr ""
+msgstr "25kV 60Hz ~"
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
-msgstr ""
+msgstr "El 3 \"Bügel ab\"-Ankündigungssignal"
 
 msgid "El 1v Ausschaltsignal erwarten"
-msgstr ""
+msgstr "El 1v Ausschaltsignal erwarten"
 
 msgid "15kV 16.7Hz ~"
-msgstr ""
+msgstr "15kV 16.7Hz ~"
 
 msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
-msgstr ""
+msgstr "Sh-Lichtsperrsignal (normal, Zwergsignal)"
 
 msgid "distant signal with Eo 2 (new type)"
-msgstr ""
+msgstr "Vorsignal mit Eo 2 (neuer Typ)"
 
 msgid "Ks-Hauptsignal"
-msgstr ""
+msgstr "Ks-Hauptsignal"
 
 msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
-msgstr ""
+msgstr "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
 
 msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
-msgstr ""
+msgstr "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
 
-msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgid ""
+"Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
 msgstr ""
+"Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
 
 msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
-msgstr ""
+msgstr "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
 
 msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
-msgstr ""
+msgstr "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
 
 msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
-msgstr ""
+msgstr "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
 
 msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
-msgstr ""
+msgstr "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
 
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
+msgstr "El 4 \"Bügel ab\"-Signal"
 
 msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
+msgstr "Vr-Formvorsignal ohne Angabe der Signalzustände"
 
 msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
-msgstr ""
+msgstr "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
 
 msgid "main signal without aspects given (new type, old type)"
-msgstr ""
+msgstr "Hauptsignal ohne Angabe der Signalzustände (neuer Typ, alter Typ)"
 
 msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
-msgstr ""
+msgstr "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
 
 msgid "main signal with Po 1 (new type, old type)"
-msgstr ""
+msgstr "Hauptsignal mit Po 1 (neuer Typ, alter Typ)"
 
 msgid "main signal with Po 2 (new type, old type)"
-msgstr ""
+msgstr "Hauptsignal mit Po 2 (neuer Typ, alter Typ)"
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
-msgstr ""
+msgstr "El 3 \"Bügel ab\"-Ankündigungssignal"
 
 msgid "distant signal with Eo 1 (new type, old type)"
-msgstr ""
+msgstr "Vorsignal mit Eo 1 (neuer Typ, alter Typ)"
 
-msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgid ""
+"Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
 msgstr ""
+"Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
 
 msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
-msgstr ""
+msgstr "Sh-Formsperrsignal (normal, Zwergsignal)"
 
 msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
-msgstr ""
+msgstr "Sv-Signal (ohne Hp 0, mit Hp 0)"
 
 msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
-msgstr ""
+msgstr "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
 
 msgid "El 5 \"Bügel an\"-Signal"
-msgstr ""
+msgstr "El 5 \"Bügel an\"-Signal"
 
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgid ""
+"Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal,"
+" Wiederholer/verkürzter Bremswegabstand)"
 msgstr ""
+"Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal,"
+" Wiederholer/verkürzter Bremswegabstand)"
 
 msgid "distant signal without aspects given (new type, old type)"
-msgstr ""
+msgstr "Vorsignal ohne Angabe der Signalzustände (neuer Typ, alter Typ)"
 
 msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
-msgstr ""
+msgstr "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
 
 msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
-msgstr ""
+msgstr "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"

--- a/locales/de_DE/LC_MESSAGES/messages.po
+++ b/locales/de_DE/LC_MESSAGES/messages.po
@@ -543,15 +543,6 @@ msgstr "Betriebsstellen"
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -561,16 +552,7 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -582,19 +564,7 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -606,49 +576,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -657,34 +597,19 @@ msgstr ""
 msgid "minor signal type Lo"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
 msgstr ""
 
-msgid "Hp-Lichthauptsignal mit Hp 2"
-msgstr ""
-
 msgid "Blockkennzeichen"
-msgstr ""
-
-msgid "Sv-Signal ohne Hp 0"
 msgstr ""
 
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -696,55 +621,25 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
-msgstr ""
-
 msgid "Ne 5 Haltetafel"
 msgstr ""
 
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -759,12 +654,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -772,9 +661,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -789,38 +675,98 @@ msgstr ""
 msgid "Punktförmige Zugbeeinflussung"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/el_GR/LC_MESSAGES/messages.po
+++ b/locales/el_GR/LC_MESSAGES/messages.po
@@ -522,9 +522,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -589,9 +586,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -769,4 +763,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/el_GR/LC_MESSAGES/messages.po
+++ b/locales/el_GR/LC_MESSAGES/messages.po
@@ -501,15 +501,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -519,19 +510,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -543,25 +525,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -573,49 +543,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -627,16 +567,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -648,19 +582,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -672,19 +597,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -696,31 +609,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -730,9 +628,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -747,12 +642,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -760,9 +649,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -786,25 +672,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -813,14 +687,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/en_GB/LC_MESSAGES/messages.po
+++ b/locales/en_GB/LC_MESSAGES/messages.po
@@ -522,9 +522,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -589,9 +586,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -769,4 +763,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/en_GB/LC_MESSAGES/messages.po
+++ b/locales/en_GB/LC_MESSAGES/messages.po
@@ -501,15 +501,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -519,19 +510,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -543,25 +525,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -573,49 +543,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -627,16 +567,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -648,19 +582,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -672,19 +597,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -696,31 +609,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -730,9 +628,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -747,12 +642,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -760,9 +649,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -786,25 +672,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -813,14 +687,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/es_ES/LC_MESSAGES/messages.po
+++ b/locales/es_ES/LC_MESSAGES/messages.po
@@ -524,9 +524,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -591,9 +588,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -771,4 +765,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/es_ES/LC_MESSAGES/messages.po
+++ b/locales/es_ES/LC_MESSAGES/messages.po
@@ -503,15 +503,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -521,19 +512,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -545,25 +527,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -575,49 +545,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -629,16 +569,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -650,19 +584,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -674,19 +599,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -698,31 +611,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -732,9 +630,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -749,12 +644,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -762,9 +651,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -788,25 +674,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -815,14 +689,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/fi_FI/LC_MESSAGES/messages.po
+++ b/locales/fi_FI/LC_MESSAGES/messages.po
@@ -522,9 +522,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -589,9 +586,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -769,4 +763,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/fi_FI/LC_MESSAGES/messages.po
+++ b/locales/fi_FI/LC_MESSAGES/messages.po
@@ -501,15 +501,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -519,19 +510,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -543,25 +525,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -573,49 +543,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -627,16 +567,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -648,19 +582,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -672,19 +597,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -696,31 +609,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -730,9 +628,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -747,12 +642,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -760,9 +649,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -786,25 +672,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -813,14 +687,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/fr_FR/LC_MESSAGES/messages.po
+++ b/locales/fr_FR/LC_MESSAGES/messages.po
@@ -523,9 +523,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -590,9 +587,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -770,4 +764,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/fr_FR/LC_MESSAGES/messages.po
+++ b/locales/fr_FR/LC_MESSAGES/messages.po
@@ -502,15 +502,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -520,19 +511,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -544,25 +526,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -574,49 +544,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -628,16 +568,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -649,19 +583,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -673,19 +598,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -697,31 +610,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -731,9 +629,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -748,12 +643,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -761,9 +650,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -787,25 +673,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -814,14 +688,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/ja_JP/LC_MESSAGES/messages.po
+++ b/locales/ja_JP/LC_MESSAGES/messages.po
@@ -496,15 +496,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -514,19 +505,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -538,25 +520,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -568,49 +538,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -622,16 +562,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -643,19 +577,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -667,19 +592,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -691,31 +604,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -725,9 +623,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -742,12 +637,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -755,9 +644,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -781,25 +667,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -808,14 +682,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/ja_JP/LC_MESSAGES/messages.po
+++ b/locales/ja_JP/LC_MESSAGES/messages.po
@@ -517,9 +517,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -584,9 +581,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -764,4 +758,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/lt_LT/LC_MESSAGES/messages.po
+++ b/locales/lt_LT/LC_MESSAGES/messages.po
@@ -528,9 +528,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -595,9 +592,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -775,4 +769,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/lt_LT/LC_MESSAGES/messages.po
+++ b/locales/lt_LT/LC_MESSAGES/messages.po
@@ -507,15 +507,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -525,19 +516,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -549,25 +531,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -579,49 +549,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -633,16 +573,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -654,19 +588,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -678,19 +603,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -702,31 +615,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -736,9 +634,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -753,12 +648,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -766,9 +655,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -792,25 +678,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -819,14 +693,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/nl_NL/LC_MESSAGES/messages.po
+++ b/locales/nl_NL/LC_MESSAGES/messages.po
@@ -523,9 +523,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -590,9 +587,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -770,4 +764,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/nl_NL/LC_MESSAGES/messages.po
+++ b/locales/nl_NL/LC_MESSAGES/messages.po
@@ -502,15 +502,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -520,19 +511,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -544,25 +526,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -574,49 +544,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -628,16 +568,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -649,19 +583,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -673,19 +598,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -697,31 +610,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -731,9 +629,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -748,12 +643,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -761,9 +650,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -787,25 +673,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -814,14 +688,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/nqo_GN/LC_MESSAGES/messages.po
+++ b/locales/nqo_GN/LC_MESSAGES/messages.po
@@ -516,9 +516,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -583,9 +580,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -763,4 +757,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/nqo_GN/LC_MESSAGES/messages.po
+++ b/locales/nqo_GN/LC_MESSAGES/messages.po
@@ -495,15 +495,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -513,19 +504,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -537,25 +519,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -567,49 +537,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -621,16 +561,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -642,19 +576,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -666,19 +591,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -690,31 +603,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -724,9 +622,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -741,12 +636,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -754,9 +643,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -780,25 +666,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -807,14 +681,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/pl_PL/LC_MESSAGES/messages.po
+++ b/locales/pl_PL/LC_MESSAGES/messages.po
@@ -513,15 +513,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -531,19 +522,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -555,25 +537,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -585,49 +555,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -639,16 +579,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -660,19 +594,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -684,19 +609,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -708,31 +621,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -742,9 +640,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -759,12 +654,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -772,9 +661,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -798,25 +684,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -825,14 +699,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/pl_PL/LC_MESSAGES/messages.po
+++ b/locales/pl_PL/LC_MESSAGES/messages.po
@@ -534,9 +534,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -601,9 +598,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -781,4 +775,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/pt_PT/LC_MESSAGES/messages.po
+++ b/locales/pt_PT/LC_MESSAGES/messages.po
@@ -522,9 +522,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -589,9 +586,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -769,4 +763,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/pt_PT/LC_MESSAGES/messages.po
+++ b/locales/pt_PT/LC_MESSAGES/messages.po
@@ -501,15 +501,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -519,19 +510,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -543,25 +525,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -573,49 +543,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -627,16 +567,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -648,19 +582,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -672,19 +597,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -696,31 +609,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -730,9 +628,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -747,12 +642,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -760,9 +649,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -786,25 +672,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -813,14 +687,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/ru_RU/LC_MESSAGES/messages.po
+++ b/locales/ru_RU/LC_MESSAGES/messages.po
@@ -516,15 +516,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -534,19 +525,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -558,25 +540,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -588,49 +558,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -642,16 +582,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -663,19 +597,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -687,19 +612,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -711,31 +624,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -745,9 +643,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -762,12 +657,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -775,9 +664,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -801,25 +687,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -828,14 +702,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/ru_RU/LC_MESSAGES/messages.po
+++ b/locales/ru_RU/LC_MESSAGES/messages.po
@@ -537,9 +537,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -604,9 +601,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -784,4 +778,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/sl_SI/LC_MESSAGES/messages.po
+++ b/locales/sl_SI/LC_MESSAGES/messages.po
@@ -513,15 +513,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -531,19 +522,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -555,25 +537,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -585,49 +555,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -639,16 +579,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -660,19 +594,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -684,19 +609,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -708,31 +621,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -742,9 +640,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -759,12 +654,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -772,9 +661,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -798,25 +684,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -825,14 +699,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/sl_SI/LC_MESSAGES/messages.po
+++ b/locales/sl_SI/LC_MESSAGES/messages.po
@@ -534,9 +534,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -601,9 +598,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -781,4 +775,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/sv_SE/LC_MESSAGES/messages.po
+++ b/locales/sv_SE/LC_MESSAGES/messages.po
@@ -523,9 +523,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -590,9 +587,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -770,4 +764,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/sv_SE/LC_MESSAGES/messages.po
+++ b/locales/sv_SE/LC_MESSAGES/messages.po
@@ -502,15 +502,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -520,19 +511,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -544,25 +526,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -574,49 +544,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -628,16 +568,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -649,19 +583,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -673,19 +598,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -697,31 +610,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -731,9 +629,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -748,12 +643,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -761,9 +650,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -787,25 +673,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -814,14 +688,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/tr_TR/LC_MESSAGES/messages.po
+++ b/locales/tr_TR/LC_MESSAGES/messages.po
@@ -522,9 +522,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -589,9 +586,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -769,4 +763,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/tr_TR/LC_MESSAGES/messages.po
+++ b/locales/tr_TR/LC_MESSAGES/messages.po
@@ -501,15 +501,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -519,19 +510,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -543,25 +525,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -573,49 +543,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -627,16 +567,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -648,19 +582,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -672,19 +597,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -696,31 +609,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -730,9 +628,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -747,12 +642,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -760,9 +649,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -786,25 +672,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -813,14 +687,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/uk_UA/LC_MESSAGES/messages.po
+++ b/locales/uk_UA/LC_MESSAGES/messages.po
@@ -528,9 +528,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -595,9 +592,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -775,4 +769,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/uk_UA/LC_MESSAGES/messages.po
+++ b/locales/uk_UA/LC_MESSAGES/messages.po
@@ -507,15 +507,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -525,19 +516,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -549,25 +531,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -579,49 +549,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -633,16 +573,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -654,19 +588,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -678,19 +603,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -702,31 +615,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -736,9 +634,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -753,12 +648,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -766,9 +655,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -792,25 +678,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -819,14 +693,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/vi_VN/LC_MESSAGES/messages.po
+++ b/locales/vi_VN/LC_MESSAGES/messages.po
@@ -496,15 +496,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -514,19 +505,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -538,25 +520,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -568,49 +538,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -622,16 +562,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -643,19 +577,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -667,19 +592,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -691,31 +604,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -725,9 +623,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -742,12 +637,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -755,9 +644,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -781,25 +667,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -808,14 +682,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/locales/vi_VN/LC_MESSAGES/messages.po
+++ b/locales/vi_VN/LC_MESSAGES/messages.po
@@ -517,9 +517,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -584,9 +581,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -764,4 +758,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/zh_TW/LC_MESSAGES/messages.po
+++ b/locales/zh_TW/LC_MESSAGES/messages.po
@@ -516,9 +516,6 @@ msgstr ""
 msgid "3kV ="
 msgstr ""
 
-msgid "Zs 3 Geschwindigkeits­anzeiger"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
@@ -583,9 +580,6 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
-
-msgid "Zs 3v Geschwindigkeits­voranzeiger"
 msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
@@ -763,4 +757,10 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
+msgstr ""
+
+msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""

--- a/locales/zh_TW/LC_MESSAGES/messages.po
+++ b/locales/zh_TW/LC_MESSAGES/messages.po
@@ -495,15 +495,6 @@ msgstr ""
 msgid "No information about train protection"
 msgstr ""
 
-msgid "Sh-Zwerg-Formsperrsignal"
-msgstr ""
-
-msgid "ex-Pf 1 Pfeiftafel"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal mit Vr 2"
-msgstr ""
-
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
@@ -513,19 +504,10 @@ msgstr ""
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
-msgid "Bü 2 Rautentafel"
-msgstr ""
-
-msgid "Sv-Signal mit Hp 0"
-msgstr ""
-
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr ""
-
-msgid "Bü 5 Läutetafel für durchfahrende Züge"
 msgstr ""
 
 msgid "ETCS under construction"
@@ -537,25 +519,13 @@ msgstr ""
 msgid "Zs 3 Geschwindigkeits­anzeiger"
 msgstr ""
 
-msgid "distant signal new type (aspects not given)"
-msgstr ""
-
 msgid "Germany"
 msgstr ""
 
 msgid "Not electrified"
 msgstr ""
 
-msgid "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
-msgid "main signal new type with Po 2"
-msgstr ""
-
 msgid "shunting signal type Ro"
-msgstr ""
-
-msgid "distant signal new type with Eo 1"
 msgstr ""
 
 msgid "Track type"
@@ -567,49 +537,19 @@ msgstr ""
 msgid "Linienzugbeeinflussung"
 msgstr ""
 
-msgid "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
-msgstr ""
-
-msgid "main signal old type (aspects not given)"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal ohne Hp 2"
-msgstr ""
-
-msgid "Bü 2 Rautentafel in verkürztem Bremswegabstand"
-msgstr ""
-
 msgid "25kV 50Hz ~"
-msgstr ""
-
-msgid "Ks-Vorsignal"
 msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
 
-msgid "Vr-Lichtvorsignal ohne Vr 2"
-msgstr ""
-
-msgid "main signal old type with Po 2"
-msgstr ""
-
 msgid "Ra 11 Wartezeichen mit Sh 1"
-msgstr ""
-
-msgid "Sh-Zwerg-Lichtsperrsignal"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer mit Vr 2"
-msgstr ""
-
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "distant signal new type with Eo 2"
 msgstr ""
 
 msgid "At least 25kV ~"
@@ -621,16 +561,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "Vr-Lichtvorsignalwiederholer ohne Vr 2"
-msgstr ""
-
 msgid "15 – 25kV ~"
 msgstr ""
 
 msgid "ETCS"
-msgstr ""
-
-msgid "Hp-Lichthauptsignal mit Hp 2"
 msgstr ""
 
 msgid "Electrification under construction"
@@ -642,19 +576,10 @@ msgstr ""
 msgid "Blockkennzeichen"
 msgstr ""
 
-msgid "Sv-Signal ohne Hp 0"
-msgstr ""
-
 msgid "Ne 6 Haltepunkttafel"
 msgstr ""
 
 msgid "Ne 1 Trapeztafel"
-msgstr ""
-
-msgid "Hp-Formhauptsignal mit Hp 2"
-msgstr ""
-
-msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
@@ -666,19 +591,7 @@ msgstr ""
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
-msgid "Bü 4 Pfeiftafel für durchfahrende Züge"
-msgstr ""
-
 msgid "signals"
-msgstr ""
-
-msgid "Sh-Formsperrsignal"
-msgstr ""
-
-msgid "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
-msgstr ""
-
-msgid "Vr-Formvorsignal ohne Vr 2"
 msgstr ""
 
 msgid "Ne 5 Haltetafel"
@@ -690,31 +603,16 @@ msgstr ""
 msgid "More than 3kV ="
 msgstr ""
 
-msgid "Hp-Formhauptsignal ohne Hp 2"
-msgstr ""
-
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
 msgstr ""
 
-msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
-msgstr ""
-
 msgid "750 – 1000V ="
 msgstr ""
 
-msgid "Ks-Hauptsignal"
-msgstr ""
-
-msgid "Bü 5 Läutetafel"
-msgstr ""
-
 msgid "Less than 15kV ~"
-msgstr ""
-
-msgid "15kV 16.7H ~"
 msgstr ""
 
 msgid "1kV ="
@@ -724,9 +622,6 @@ msgid "crossing signal type To"
 msgstr ""
 
 msgid "1 – 1.5kV ="
-msgstr ""
-
-msgid "Ks-Vorsignal in verkürztem Bremswegabstand"
 msgstr ""
 
 msgid "block signal type So"
@@ -741,12 +636,6 @@ msgstr ""
 msgid "El 2 Einschaltsignal"
 msgstr ""
 
-msgid "main signal old type with Po 1"
-msgstr ""
-
-msgid "distant signal old type (aspects not given)"
-msgstr ""
-
 msgid "Ra 10 Rangierhalttafel / Verschubhalttafel"
 msgstr ""
 
@@ -754,9 +643,6 @@ msgid "Zs 10 Endesignal (Tafel)"
 msgstr ""
 
 msgid "El 1 Ausschaltsignal"
-msgstr ""
-
-msgid "Sh-Lichtsperrsignal"
 msgstr ""
 
 msgid "Ra 11b Wartezeichen"
@@ -780,25 +666,13 @@ msgstr ""
 msgid "contact line"
 msgstr ""
 
-msgid "main signal new type (aspects not given)"
-msgstr ""
-
 msgid "El 4 \"Bügel ab\"-Signal"
-msgstr ""
-
-msgid "Ks-Mehrabschnittssignal"
 msgstr ""
 
 msgid "750V ="
 msgstr ""
 
-msgid "distant signal old type with Eo 1"
-msgstr ""
-
 msgid "25kV 60Hz ~"
-msgstr ""
-
-msgid "main signal new type with Po 1"
 msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
@@ -807,14 +681,86 @@ msgstr ""
 msgid "Electrification proposed"
 msgstr ""
 
-msgid "Vr-Formvorsignal mit Vr 2"
-msgstr ""
-
-msgid "Ks-Vorsignalwiederholer"
-msgstr ""
-
-msgid "Bü 4 Pfeiftafel"
-msgstr ""
-
 msgid "El 1v Ausschaltsignal erwarten"
+msgstr ""
+
+msgid "15kV 16.7Hz ~"
+msgstr ""
+
+msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "distant signal with Eo 2 (new type)"
+msgstr ""
+
+msgid "Ks-Hauptsignal"
+msgstr ""
+
+msgid "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
+msgstr ""
+
+msgid "El 4 \"Bügel ab\"-Signal"
+msgstr ""
+
+msgid "Vr-Formvorsignal ohne Angabe der Signalzustände"
+msgstr ""
+
+msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+msgstr ""
+
+msgid "main signal without aspects given (new type, old type)"
+msgstr ""
+
+msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "main signal with Po 1 (new type, old type)"
+msgstr ""
+
+msgid "main signal with Po 2 (new type, old type)"
+msgstr ""
+
+msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
+msgstr ""
+
+msgid "distant signal with Eo 1 (new type, old type)"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "Sh-Formsperrsignal (normal, Zwergsignal)"
+msgstr ""
+
+msgid "Sv-Signal (ohne Hp 0, mit Hp 0)"
+msgstr ""
+
+msgid "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
+msgstr ""
+
+msgid "El 5 \"Bügel an\"-Signal"
+msgstr ""
+
+msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
+msgstr ""
+
+msgid "distant signal without aspects given (new type, old type)"
 msgstr ""

--- a/styles/electrified.json
+++ b/styles/electrified.json
@@ -4,43 +4,94 @@
 	[
 		{
 			"minzoom": 2,
-			"symbol": "<g fill='none' stroke='gray' stroke-width='2'><path stroke-linecap='butt' d='M5 8 l32 0' /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail"
+				}
+			}],
 			"caption": "No information"
 		},
 		{
 			"minzoom": 2,
-			"symbol": "<g fill='none' stroke='black' stroke-width='2'><path stroke-linecap='butt' d='M5 8 l32 0' /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"electrified":"no"
+				}
+			}],
 			"caption": "Not electrified"
 		},
 		{
 			"minzoom": 2,
-			"symbol": "<g fill='none' stroke='#70584D' stroke-width='2'><path stroke-linecap='butt' d='M5 8 l32 0' /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"electrified":"no",
+					"deelectrified":"contact_line"
+				}
+			}],
 			"caption": "Deelectrified"
 		},
 		{
 			"minzoom": 2,
-			"symbol": "<g fill='none' stroke='gray' stroke-width='2'><path stroke-linecap='butt' stroke-dasharray=\"2,8\" d='M5 8 l32 0' /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"proposed:voltage":"25000",
+					"proposed:frequency":"50",
+					"proposed:electrified":"contact_line"
+				}
+			}],
 			"caption": "Electrification proposed"
 		},
 		{
 			"minzoom": 2,
-			"symbol": "<g fill='none' stroke='gray' stroke-width='2'><path stroke-linecap='butt' stroke-dasharray=\"5,5\" d='M5 8 l32 0' /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"construction:voltage":"25000",
+					"construction:frequency":"50",
+					"construction:electrified":"contact_line"
+				}
+			}],
 			"caption": "Electrification under construction"
 		},
 		{
 			"minzoom": 2,
-			"symbol": "<g fill='none' stroke='#797979' stroke-width='2'><path stroke-linecap='butt' d='M5 8 l32 0' /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"voltage":"25000",
+					"frequency":"50",
+					"electrified":"contact_line"
+				}
+			}],
 			"caption": "contact line"
 		},
 		{
 			"minzoom": 2,
-			"maxzoom": 15,
-			"symbol": "<g fill='none' stroke-width='2'><path stroke='#797979' stroke-linecap='butt' d='M5 6 l32 0' /><path stroke='white' stroke-linecap='butt' d='M5 8 l32 0' /><path stroke='#797979' stroke-linecap='butt' d='M5 10 l32 0' /></g>",
-			"caption": "3rd rail"
-		},
-		{
-			"minzoom": 16,
-			"symbol": "<g fill='none' stroke-width='3'><path stroke='#797979' stroke-linecap='butt' d='M5 5 l32 0' /><path stroke-width='2' stroke='white' stroke-linecap='butt' d='M5 8 l32 0' /><path stroke='#797979' stroke-linecap='butt' d='M5 10 l32 0' /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"voltage":"25000",
+					"frequency":"50",
+					"electrified":"rail"
+				}
+			}],
 			"caption": "3rd rail"
 		},
 		{
@@ -50,24 +101,33 @@
 		{
 			"minzoom": 2,
 			"replace": [
-				{ "%COLOR%":"FF79B8","%CAPTION%":"Less than 750V =" },
-				{ "%COLOR%":"F930FF","%CAPTION%":"750V =" },
-				{ "%COLOR%":"D033FF","%CAPTION%":"750 – 1000V =" },
-				{ "%COLOR%":"5C1CCB","%CAPTION%":"1kV =" },
-				{ "%COLOR%":"007ACB","%CAPTION%":"1 – 1.5kV =" },
-				{ "%COLOR%":"0098CB","%CAPTION%":"1.5kV =" },
-				{ "%COLOR%":"00B7CB","%CAPTION%": "1.5 – 3kV ="},
-				{ "%COLOR%":"0000FF","%CAPTION%": "3kV ="},
-				{ "%COLOR%":"1969FF","%CAPTION%": "More than 3kV ="},
-				{ "%COLOR%":"97FF2F","%CAPTION%": "Less than 15kV ~"},
-				{ "%COLOR%":"00FF00","%CAPTION%": "15kV 16⅔Hz ~"},
-				{ "%COLOR%":"00CB66","%CAPTION%": "15kV 16.7H ~"},
-				{ "%COLOR%":"F1F100","%CAPTION%": "15 – 25kV ~"},
-				{ "%COLOR%":"FF9F19","%CAPTION%": "At least 25kV ~"},
-				{ "%COLOR%":"FF0000","%CAPTION%": "25kV 50Hz ~"},
-				{ "%COLOR%":"C00000","%CAPTION%": "25kV 60Hz ~"}
+				{ "%VOLTAGE%":  600,"%FREQUENCY%":0,"%CAPTION%":"Less than 750V =" },
+				{ "%VOLTAGE%":  750,"%FREQUENCY%":0,"%CAPTION%":"750V =" },
+				{ "%VOLTAGE%":  800,"%FREQUENCY%":0,"%CAPTION%":"750 – 1000V =" },
+				{ "%VOLTAGE%": 1000,"%FREQUENCY%":0,"%CAPTION%":"1kV =" },
+				{ "%VOLTAGE%": 1200,"%FREQUENCY%":0,"%CAPTION%":"1 – 1.5kV =" },
+				{ "%VOLTAGE%": 1500,"%FREQUENCY%":0,"%CAPTION%":"1.5kV =" },
+				{ "%VOLTAGE%": 2000,"%FREQUENCY%":0,"%CAPTION%":"1.5 – 3kV =" },
+				{ "%VOLTAGE%": 3000,"%FREQUENCY%":0,"%CAPTION%":"3kV =" },
+				{ "%VOLTAGE%": 5000,"%FREQUENCY%":0,"%CAPTION%":"More than 3kV =" },
+				{ "%VOLTAGE%":10000,"%FREQUENCY%":25,"%CAPTION%":"Less than 15kV ~" },
+				{ "%VOLTAGE%":15000,"%FREQUENCY%":"16.67","%CAPTION%":"15kV 16⅔Hz ~" },
+				{ "%VOLTAGE%":15000,"%FREQUENCY%":"16.7","%CAPTION%":"15kV 16.7Hz ~" },
+				{ "%VOLTAGE%":20000,"%FREQUENCY%":25,"%CAPTION%":"15 – 25kV ~" },
+				{ "%VOLTAGE%":26000,"%FREQUENCY%":25,"%CAPTION%":"At least 25kV ~" },
+				{ "%VOLTAGE%":25000,"%FREQUENCY%":50,"%CAPTION%":"25kV 50Hz ~" },
+				{ "%VOLTAGE%":25000,"%FREQUENCY%":60,"%CAPTION%":"25kV 60Hz ~" }
 			],
-			"symbol": "<g fill='none' stroke='#%COLOR%' stroke-width='2'><path stroke-linecap='butt' d='M5 8 l32 0' /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"voltage":"%VOLTAGE%",
+					"frequency":"%FREQUENCY%",
+					"electrified":"contact_line"
+				}
+			}],
 			"caption": "%CAPTION%"
 		},
 		{
@@ -77,15 +137,25 @@
 		{
 			"minzoom": 17,
 			"replace": [
-				{ "%SIGNAL%":"el1v", "%CAPTION%":"El 1v Ausschaltsignal erwarten" },
-				{ "%SIGNAL%":"el1", "%CAPTION%":"El 1 Ausschaltsignal" },
-				{ "%SIGNAL%":"el2", "%CAPTION%":"El 2 Einschaltsignal" },
-				{ "%SIGNAL%":"el3", "%CAPTION%":"El 3 \"Bügel ab\"-Ankündigungssignal" },
-				{ "%SIGNAL%":"el4", "%CAPTION%":"El 4 \"Bügel ab\"-Signal" },
-				{ "%SIGNAL%":"el5", "%CAPTION%":"El 5 \"Bügel an\"-Signal" },
-				{ "%SIGNAL%":"el6", "%CAPTION%":"El 6 Halt für Fahrzeuge mit gehobenem Stromabnehmer" }
+				{ "%SIGNAL%":"el1v", "%TYPE%":"power_off_advance", "%CAPTION%":"El 1v Ausschaltsignal erwarten" },
+				{ "%SIGNAL%":"el1", "%TYPE%":"power_off", "%CAPTION%":"El 1 Ausschaltsignal" },
+				{ "%SIGNAL%":"el2", "%TYPE%":"power_on", "%CAPTION%":"El 2 Einschaltsignal" },
+				{ "%SIGNAL%":"el3", "%TYPE%":"pantograph_down_advance", "%CAPTION%":"El 3 \"Bügel ab\"-Ankündigungssignal" },
+				{ "%SIGNAL%":"el4", "%TYPE%":"pantograph_down", "%CAPTION%":"El 4 \"Bügel ab\"-Signal" },
+				{ "%SIGNAL%":"el5", "%TYPE%":"pantograph_up", "%CAPTION%":"El 5 \"Bügel an\"-Signal" },
+				{ "%SIGNAL%":"el6", "%TYPE%":"end_of_catenary", "%CAPTION%":"El 6 Halt für Fahrzeuge mit gehobenem Stromabnehmer" }
 			],
-			"icon": "icons/de/%SIGNAL%-28.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:electricity":"DE-ESO:%SIGNAL%",
+					"railway:signal:electricity:type":"%TYPE%",
+					"railway:signal:electricity:form":"sign"
+				}
+			}],
 			"caption": "%CAPTION%"
 		}
 	]

--- a/styles/maxspeed.json
+++ b/styles/maxspeed.json
@@ -116,32 +116,52 @@
 			"lineheight": 20,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [35,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:speed_limit_distant":"DE-ESO:zs3v",
 					"railway:signal:speed_limit_distant:form":"sign",
 					"railway:signal:speed_limit_distant:speed":"30"
+				}},
+				{
+				"type": "Point",
+				"coordinates": [65,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:speed_limit_distant":"DE-ESO:zs3v",
+					"railway:signal:speed_limit_distant:form":"light",
+					"railway:signal:speed_limit_distant:speed":"30"
 				}
 			}],
-			"caption": "Zs 3v Geschwindigkeits­voranzeiger"
+			"caption": "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
 		},
 		{
 			"minzoom": 17,
 			"lineheight": 20,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [35,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:speed_limit":"DE-ESO:zs3",
 					"railway:signal:speed_limit:form":"sign",
 					"railway:signal:speed_limit:speed":"30"
+				}},
+				{
+				"type": "Point",
+				"coordinates": [65,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:speed_limit":"DE-ESO:zs3",
+					"railway:signal:speed_limit:form":"light",
+					"railway:signal:speed_limit:speed":"30"
 				}
 			}],
-			"caption": "Zs 3 Geschwindigkeits­anzeiger"
+			"caption": "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 		},
 		{
 			"minzoom": 14,

--- a/styles/maxspeed.json
+++ b/styles/maxspeed.json
@@ -4,12 +4,16 @@
 	[
 		{
 			"minzoom": 2,
-			"symbol": "<g fill=\"none\" stroke=\"gray\" stroke-width=\"3.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [
+				{"type": "LineString", "coordinates": [[10,50],[80,50]], "properties": { "railway":"rail", "usage":"main" }}
+			],
 			"caption": "No information"
 		},
 		{
 			"minzoom": 12,
-			"symbol": "<g fill=\"none\" stroke=\"gray\" stroke-width=\"3\"><path stroke-linecap=\"butt\" stroke-dasharray=\"4,4\" d=\"M5 8 l32 0\" /></g>",
+			"features": [
+				{"type": "LineString", "coordinates": [[10,50],[80,50]], "properties": { "railway":"rail", "usage":"main", "maxspeed:forward": 1 }}
+			],
 			"caption": "speed only given for one direction"
 		},
 		{
@@ -21,110 +25,169 @@
 			"minzoom": 2,
 			"maxzoom": 8,
 			"replace": [
-				{"%SPDMIN%":  1,"%SPDMAX%": 10, "%COLORUSED%":"0100CB"},
-				{"%SPDMIN%": 11,"%SPDMAX%": 20, "%COLORUSED%":"001ECB"},
-				{"%SPDMIN%": 21,"%SPDMAX%": 30, "%COLORUSED%":"003DCB"},
-				{"%SPDMIN%": 31,"%SPDMAX%": 40, "%COLORUSED%":"005BCB"},
-				{"%SPDMIN%": 41,"%SPDMAX%": 50, "%COLORUSED%":"007ACB"},
-				{"%SPDMIN%": 51,"%SPDMAX%": 60, "%COLORUSED%":"0098CB"},
-				{"%SPDMIN%": 61,"%SPDMAX%": 70, "%COLORUSED%":"00B7CB"},
-				{"%SPDMIN%": 71,"%SPDMAX%": 80, "%COLORUSED%":"00CBC1"},
-				{"%SPDMIN%": 81,"%SPDMAX%": 90, "%COLORUSED%":"00CBA2"},
-				{"%SPDMIN%": 91,"%SPDMAX%":100, "%COLORUSED%":"00CB84"},
-				{"%SPDMIN%":101,"%SPDMAX%":110, "%COLORUSED%":"00CB66"},
-				{"%SPDMIN%":111,"%SPDMAX%":120, "%COLORUSED%":"00CB47"},
-				{"%SPDMIN%":121,"%SPDMAX%":130, "%COLORUSED%":"00CB29"},
-				{"%SPDMIN%":131,"%SPDMAX%":140, "%COLORUSED%":"00CB0A"},
-				{"%SPDMIN%":141,"%SPDMAX%":150, "%COLORUSED%":"14CB00"},
-				{"%SPDMIN%":151,"%SPDMAX%":160, "%COLORUSED%":"33CB00"},
-				{"%SPDMIN%":161,"%SPDMAX%":170, "%COLORUSED%":"51CB00"},
-				{"%SPDMIN%":171,"%SPDMAX%":180, "%COLORUSED%":"70CB00"},
-				{"%SPDMIN%":181,"%SPDMAX%":190, "%COLORUSED%":"8ECB00"},
-				{"%SPDMIN%":191,"%SPDMAX%":200, "%COLORUSED%":"ADCB00"},
-				{"%SPDMIN%":201,"%SPDMAX%":210, "%COLORUSED%":"CBCB00"},
-				{"%SPDMIN%":211,"%SPDMAX%":220, "%COLORUSED%":"CBAD00"},
-				{"%SPDMIN%":221,"%SPDMAX%":230, "%COLORUSED%":"CB8E00"},
-				{"%SPDMIN%":231,"%SPDMAX%":240, "%COLORUSED%":"CB7000"},
-				{"%SPDMIN%":241,"%SPDMAX%":250, "%COLORUSED%":"CB5100"},
-				{"%SPDMIN%":251,"%SPDMAX%":260, "%COLORUSED%":"CB3300"},
-				{"%SPDMIN%":261,"%SPDMAX%":270, "%COLORUSED%":"CB1400"},
-				{"%SPDMIN%":271,"%SPDMAX%":280, "%COLORUSED%":"CB0007"},
-				{"%SPDMIN%":281,"%SPDMAX%":290, "%COLORUSED%":"CB0025"},
-				{"%SPDMIN%":291,"%SPDMAX%":300, "%COLORUSED%":"CB0044"},
-				{"%SPDMIN%":301,"%SPDMAX%":320, "%COLORUSED%":"CB0062"},
-				{"%SPDMIN%":321,"%SPDMAX%":340, "%COLORUSED%":"CB0081"},
-				{"%SPDMIN%":341,"%SPDMAX%":360, "%COLORUSED%":"CB009F"},
-				{"%SPDMIN%":361,"%SPDMAX%":380, "%COLORUSED%":"CB00BD"},
-				{"%SPDMIN%":381,"%SPDMAX%":400, "%COLORUSED%":"BA00CB"}
+				{"%SPDMIN%":  1,"%SPDMAX%": 10},
+				{"%SPDMIN%": 11,"%SPDMAX%": 20},
+				{"%SPDMIN%": 21,"%SPDMAX%": 30},
+				{"%SPDMIN%": 31,"%SPDMAX%": 40},
+				{"%SPDMIN%": 41,"%SPDMAX%": 50},
+				{"%SPDMIN%": 51,"%SPDMAX%": 60},
+				{"%SPDMIN%": 61,"%SPDMAX%": 70},
+				{"%SPDMIN%": 71,"%SPDMAX%": 80},
+				{"%SPDMIN%": 81,"%SPDMAX%": 90},
+				{"%SPDMIN%": 91,"%SPDMAX%":100},
+				{"%SPDMIN%":101,"%SPDMAX%":110},
+				{"%SPDMIN%":111,"%SPDMAX%":120},
+				{"%SPDMIN%":121,"%SPDMAX%":130},
+				{"%SPDMIN%":131,"%SPDMAX%":140},
+				{"%SPDMIN%":141,"%SPDMAX%":150},
+				{"%SPDMIN%":151,"%SPDMAX%":160},
+				{"%SPDMIN%":161,"%SPDMAX%":170},
+				{"%SPDMIN%":171,"%SPDMAX%":180},
+				{"%SPDMIN%":181,"%SPDMAX%":190},
+				{"%SPDMIN%":191,"%SPDMAX%":200},
+				{"%SPDMIN%":201,"%SPDMAX%":210},
+				{"%SPDMIN%":211,"%SPDMAX%":220},
+				{"%SPDMIN%":221,"%SPDMAX%":230},
+				{"%SPDMIN%":231,"%SPDMAX%":240},
+				{"%SPDMIN%":241,"%SPDMAX%":250},
+				{"%SPDMIN%":251,"%SPDMAX%":260},
+				{"%SPDMIN%":261,"%SPDMAX%":270},
+				{"%SPDMIN%":271,"%SPDMAX%":280},
+				{"%SPDMIN%":281,"%SPDMAX%":290},
+				{"%SPDMIN%":291,"%SPDMAX%":300},
+				{"%SPDMIN%":301,"%SPDMAX%":320},
+				{"%SPDMIN%":321,"%SPDMAX%":340},
+				{"%SPDMIN%":341,"%SPDMAX%":360},
+				{"%SPDMIN%":361,"%SPDMAX%":380},
+				{"%SPDMIN%":381,"%SPDMAX%":400}
 			],
-			"symbol": "<g fill=\"none\" stroke=\"#%COLORUSED%\" stroke-width=\"3.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l16 0\" /></g>",
+			"features": [
+				{"type": "LineString", "coordinates": [[10,50],[45,50]], "properties": { "maxspeed":"%SPDMIN%", "railway":"rail", "usage":"main" }}
+			],
 			"caption": "%SPDMIN%-%SPDMAX% km/h"
 		},
 		{
 			"minzoom": 9,
 			"replace": [
-				{"%SPDMIN%":  1,"%SPDMAX%": 10, "%COLORUSED%":"0100CB", "%COLORCONSTR%":"9595e9"},
-				{"%SPDMIN%": 11,"%SPDMAX%": 20, "%COLORUSED%":"001ECB", "%COLORCONSTR%":"95a1e9"},
-				{"%SPDMIN%": 21,"%SPDMAX%": 30, "%COLORUSED%":"003DCB", "%COLORCONSTR%":"95aee9"},
-				{"%SPDMIN%": 31,"%SPDMAX%": 40, "%COLORUSED%":"005BCB", "%COLORCONSTR%":"95bbe9"},
-				{"%SPDMIN%": 41,"%SPDMAX%": 50, "%COLORUSED%":"007ACB", "%COLORCONSTR%":"95c8e9"},
-				{"%SPDMIN%": 51,"%SPDMAX%": 60, "%COLORUSED%":"0098CB", "%COLORCONSTR%":"95d4e9"},
-				{"%SPDMIN%": 61,"%SPDMAX%": 70, "%COLORUSED%":"00B7CB", "%COLORCONSTR%":"95e1e9"},
-				{"%SPDMIN%": 71,"%SPDMAX%": 80, "%COLORUSED%":"00CBC1", "%COLORCONSTR%":"95e9e5"},
-				{"%SPDMIN%": 81,"%SPDMAX%": 90, "%COLORUSED%":"00CBA2", "%COLORCONSTR%":"95e9d8"},
-				{"%SPDMIN%": 91,"%SPDMAX%":100, "%COLORUSED%":"00CB84", "%COLORCONSTR%":"95e9cc"},
-				{"%SPDMIN%":101,"%SPDMAX%":110, "%COLORUSED%":"00CB66", "%COLORCONSTR%":"95e9bf"},
-				{"%SPDMIN%":111,"%SPDMAX%":120, "%COLORUSED%":"00CB47", "%COLORCONSTR%":"95e9b3"},
-				{"%SPDMIN%":121,"%SPDMAX%":130, "%COLORUSED%":"00CB29", "%COLORCONSTR%":"95e9a6"},
-				{"%SPDMIN%":131,"%SPDMAX%":140, "%COLORUSED%":"00CB0A", "%COLORCONSTR%":"95e999"},
-				{"%SPDMIN%":141,"%SPDMAX%":150, "%COLORUSED%":"14CB00", "%COLORCONSTR%":"9de995"},
-				{"%SPDMIN%":151,"%SPDMAX%":160, "%COLORUSED%":"33CB00", "%COLORCONSTR%":"aae995"},
-				{"%SPDMIN%":161,"%SPDMAX%":170, "%COLORUSED%":"51CB00", "%COLORCONSTR%":"b7e995"},
-				{"%SPDMIN%":171,"%SPDMAX%":180, "%COLORUSED%":"70CB00", "%COLORCONSTR%":"c4e995"},
-				{"%SPDMIN%":181,"%SPDMAX%":190, "%COLORUSED%":"8ECB00", "%COLORCONSTR%":"d0e995"},
-				{"%SPDMIN%":191,"%SPDMAX%":200, "%COLORUSED%":"ADCB00", "%COLORCONSTR%":"dde995"},
-				{"%SPDMIN%":201,"%SPDMAX%":210, "%COLORUSED%":"CBCB00", "%COLORCONSTR%":"e9e995"},
-				{"%SPDMIN%":211,"%SPDMAX%":220, "%COLORUSED%":"CBAD00", "%COLORCONSTR%":"e9dd95"},
-				{"%SPDMIN%":221,"%SPDMAX%":230, "%COLORUSED%":"CB8E00", "%COLORCONSTR%":"e9d095"},
-				{"%SPDMIN%":231,"%SPDMAX%":240, "%COLORUSED%":"CB7000", "%COLORCONSTR%":"e9c495"},
-				{"%SPDMIN%":241,"%SPDMAX%":250, "%COLORUSED%":"CB5100", "%COLORCONSTR%":"e9b795"},
-				{"%SPDMIN%":251,"%SPDMAX%":260, "%COLORUSED%":"CB3300", "%COLORCONSTR%":"e9aa95"},
-				{"%SPDMIN%":261,"%SPDMAX%":270, "%COLORUSED%":"CB1400", "%COLORCONSTR%":"e99d95"},
-				{"%SPDMIN%":271,"%SPDMAX%":280, "%COLORUSED%":"CB0007", "%COLORCONSTR%":"e99598"},
-				{"%SPDMIN%":281,"%SPDMAX%":290, "%COLORUSED%":"CB0025", "%COLORCONSTR%":"e995a4"},
-				{"%SPDMIN%":291,"%SPDMAX%":300, "%COLORUSED%":"CB0044", "%COLORCONSTR%":"e995b1"},
-				{"%SPDMIN%":301,"%SPDMAX%":320, "%COLORUSED%":"CB0062", "%COLORCONSTR%":"e995be"},
-				{"%SPDMIN%":321,"%SPDMAX%":340, "%COLORUSED%":"CB0081", "%COLORCONSTR%":"e995cb"},
-				{"%SPDMIN%":341,"%SPDMAX%":360, "%COLORUSED%":"CB009F", "%COLORCONSTR%":"e995d7"},
-				{"%SPDMIN%":361,"%SPDMAX%":380, "%COLORUSED%":"CB00BD", "%COLORCONSTR%":"e995e4"},
-				{"%SPDMIN%":381,"%SPDMAX%":400, "%COLORUSED%":"BA00CB", "%COLORCONSTR%":"e295e9"}
+				{"%SPDMIN%":  1,"%SPDMAX%": 10},
+				{"%SPDMIN%": 11,"%SPDMAX%": 20},
+				{"%SPDMIN%": 21,"%SPDMAX%": 30},
+				{"%SPDMIN%": 31,"%SPDMAX%": 40},
+				{"%SPDMIN%": 41,"%SPDMAX%": 50},
+				{"%SPDMIN%": 51,"%SPDMAX%": 60},
+				{"%SPDMIN%": 61,"%SPDMAX%": 70},
+				{"%SPDMIN%": 71,"%SPDMAX%": 80},
+				{"%SPDMIN%": 81,"%SPDMAX%": 90},
+				{"%SPDMIN%": 91,"%SPDMAX%":100},
+				{"%SPDMIN%":101,"%SPDMAX%":110},
+				{"%SPDMIN%":111,"%SPDMAX%":120},
+				{"%SPDMIN%":121,"%SPDMAX%":130},
+				{"%SPDMIN%":131,"%SPDMAX%":140},
+				{"%SPDMIN%":141,"%SPDMAX%":150},
+				{"%SPDMIN%":151,"%SPDMAX%":160},
+				{"%SPDMIN%":161,"%SPDMAX%":170},
+				{"%SPDMIN%":171,"%SPDMAX%":180},
+				{"%SPDMIN%":181,"%SPDMAX%":190},
+				{"%SPDMIN%":191,"%SPDMAX%":200},
+				{"%SPDMIN%":201,"%SPDMAX%":210},
+				{"%SPDMIN%":211,"%SPDMAX%":220},
+				{"%SPDMIN%":221,"%SPDMAX%":230},
+				{"%SPDMIN%":231,"%SPDMAX%":240},
+				{"%SPDMIN%":241,"%SPDMAX%":250},
+				{"%SPDMIN%":251,"%SPDMAX%":260},
+				{"%SPDMIN%":261,"%SPDMAX%":270},
+				{"%SPDMIN%":271,"%SPDMAX%":280},
+				{"%SPDMIN%":281,"%SPDMAX%":290},
+				{"%SPDMIN%":291,"%SPDMAX%":300},
+				{"%SPDMIN%":301,"%SPDMAX%":320},
+				{"%SPDMIN%":321,"%SPDMAX%":340},
+				{"%SPDMIN%":341,"%SPDMAX%":360},
+				{"%SPDMIN%":361,"%SPDMAX%":380},
+				{"%SPDMIN%":381,"%SPDMAX%":400}
 			],
-			"symbol": "<g fill=\"none\" stroke=\"#%COLORUSED%\" stroke-width=\"3.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l16 0\" /></g><g fill=\"none\" stroke=\"#%COLORCONSTR%\" stroke-width=\"3.5\"><path stroke-linecap=\"butt\" d=\"M21 8 l16 0\" /></g>",
+			"features": [
+				{"type": "LineString", "coordinates": [[10,50],[45,50]], "properties": { "maxspeed":"%SPDMIN%", "railway":"rail", "usage":"main" }},
+				{"type": "LineString", "coordinates": [[45,50],[80,50]], "properties": { "maxspeed":"%SPDMAX%", "construction:railway":"rail", "railway":"construction" }}
+			],
 			"caption": "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 		},
 		{
 			"minzoom": 17,
-			"icon": "icons/de/zs3v-50-sign-down-22.png",
+			"lineheight": 20,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:speed_limit_distant":"DE-ESO:zs3v",
+					"railway:signal:speed_limit_distant:form":"sign",
+					"railway:signal:speed_limit_distant:speed":"30"
+				}
+			}],
 			"caption": "Zs 3v Geschwindigkeits­voranzeiger"
 		},
 		{
 			"minzoom": 17,
-			"icon": "icons/de/zs3-60-sign-up-22.png",
+			"lineheight": 20,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:speed_limit":"DE-ESO:zs3",
+					"railway:signal:speed_limit:form":"sign",
+					"railway:signal:speed_limit:speed":"30"
+				}
+			}],
 			"caption": "Zs 3 Geschwindigkeits­anzeiger"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/lf6-60-sign-down-22.png",
+			"lineheight": 20,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:speed_limit_distant":"DE-ESO:lf6",
+					"railway:signal:speed_limit_distant:form":"sign",
+					"railway:signal:speed_limit_distant:speed":"60"
+				}
+			}],
 			"caption": "Lf 6 Geschwindigkeits­ankündesignal"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/lf7-70-sign-22.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:speed_limit":"DE-ESO:lf7",
+					"railway:signal:speed_limit:form":"sign",
+					"railway:signal:speed_limit:speed":"70"
+				}
+			}],
 			"caption": "Lf 7 Geschwindigkeitssignal"
 		},
 		{
-			"minzoom": 17,
-			"icon": "icons/de/zs10-sign-22.png",
+			"minzoom": 16,
+			"lineheight": 24,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:speed_limit":"DE-ESO:db:zs10",
+					"railway:signal:speed_limit:form":"sign",
+					"railway:signal:speed_limit:speed":"none"
+				}
+			}],
 			"caption": "Zs 10 Endesignal (Tafel)"
 		}
 	]

--- a/styles/signals.json
+++ b/styles/signals.json
@@ -8,38 +8,94 @@
 		},
 		{
 			"minzoom": 2,
-			"symbol": "<g fill=\"none\" stroke=\"gray\" stroke-width=\"3.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"usage":"main"
+				}
+			}],
 			"caption": "No information about train protection"
 		},
 		{
 			"minzoom": 2,
-			"symbol": "<g fill=\"none\" stroke=\"black\" stroke-width=\"2.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"railway:etcs":"no",
+					"railway:lzb":"no",
+					"railway:pzb":"no",
+					"usage":"main"
+				}
+			}],
 			"caption": "no train protection"
 		},
 		{
 			"minzoom": 2,
-			"symbol": "<g fill=\"none\" stroke=\"#FFB900\" stroke-width=\"3.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"railway:pzb":"yes",
+					"usage":"main"
+				}
+			}],
 			"caption": "Punktförmige Zugbeeinflussung"
 		},
 		{
 			"minzoom": 2,
-			"symbol": "<g fill=\"none\" stroke=\"red\" stroke-width=\"3.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"railway:lzb":"yes",
+					"usage":"main"
+				}
+			}],
 			"caption": "Linienzugbeeinflussung"
 		},
 		{
 			"minzoom": 2,
-			"symbol": "<g fill=\"none\" stroke=\"blue\" stroke-width=\"3.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"railway:etcs":"yes",
+					"usage":"main"
+				}
+			}],
 			"caption": "ETCS"
 		},
 		{
 			"minzoom": 5,
-			"maxzoom": 19,
-			"symbol": "<g fill=\"none\" stroke=\"blue\" stroke-width=\"3\"><path stroke-linecap=\"butt\" stroke-dasharray=\"9,9\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"construction:railway:etcs":"yes",
+					"usage":"main"
+				}
+			}],
 			"caption": "ETCS under construction"
 		},
 		{
 			"minzoom": 13,
-			"symbol": "<text x=\"0\" y=\"11\" style=\"font-family: Arial; font-size: 11px; fill: black; stroke: #008206; stroke-width: 0.5;\">Dormagen Df</text>",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"name":"Dormagen Df",
+					"railway":"signal_box",
+					"railway:ref":"Df"
+				}
+			}],
 			"caption": "Signal box"
 		},
 		{
@@ -48,231 +104,642 @@
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/hp0-semaphore-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"DE-ESO:hp",
+					"railway:signal:main:form":"semaphore"
+				}
+			}],
 			"caption": "Hp-Formhauptsignal ohne Angabe der Signalzustände"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/hp1-semaphore-19.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"DE-ESO:hp",
+					"railway:signal:main:form":"semaphore",
+					"railway:signal:main:states":"DE-ESO:hp1"
+				}
+			}],
 			"caption": "Hp-Formhauptsignal ohne Hp 2"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/hp2-semaphore-20.png",
+			"lineheight": 20,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"DE-ESO:hp",
+					"railway:signal:main:form":"semaphore",
+					"railway:signal:main:states":"DE-ESO:hp2"
+				}
+			}],
 			"caption": "Hp-Formhauptsignal mit Hp 2"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/hp0-light-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"DE-ESO:hp",
+					"railway:signal:main:form":"light"
+				}
+			}],
 			"caption": "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/hp1-light-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"DE-ESO:hp",
+					"railway:signal:main:form":"light",
+					"railway:signal:main:states":"DE-ESO:hp1"
+				}
+			}],
 			"caption": "Hp-Lichthauptsignal ohne Hp 2"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/hp2-light-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"DE-ESO:hp",
+					"railway:signal:main:form":"light",
+					"railway:signal:main:states":"DE-ESO:hp2"
+				}
+			}],
 			"caption": "Hp-Lichthauptsignal mit Hp 2"
 		},
 		{
 			"minzoom": 17,
-			"icon": "icons/de/sh1-semaphore-normal-12.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:minor":"DE-ESO:sh",
+					"railway:signal:minor:form":"semaphore"
+				}
+			}],
 			"caption": "Sh-Formsperrsignal"
 		},
 		{
 			"minzoom": 17,
-			"icon": "icons/de/sh0-semaphore-dwarf-12.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:minor":"DE-ESO:sh",
+					"railway:signal:minor:form":"semaphore",
+					"railway:signal:minor:height":"dwarf"
+				}
+			}],
 			"caption": "Sh-Zwerg-Formsperrsignal"
 		},
 		{
 			"minzoom": 17,
-			"icon": "icons/de/sh1-light-normal-12.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:minor":"DE-ESO:sh",
+					"railway:signal:minor:form":"light"
+				}
+			}],
 			"caption": "Sh-Lichtsperrsignal"
 		},
 		{
 			"minzoom": 17,
-			"icon": "icons/de/sh0-light-dwarf-12.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:minor":"DE-ESO:sh",
+					"railway:signal:minor:form":"light",
+					"railway:signal:minor:height":"dwarf"
+				}
+			}],
 			"caption": "Sh-Zwerg-Lichtsperrsignal"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/ks-distant-repeated-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:ks",
+					"railway:signal:distant:form":"light",
+					"railway:signal:distant:repeated":"yes"
+				}
+			}],
 			"caption": "Ks-Vorsignalwiederholer"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/ks-distant-shortened-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:ks",
+					"railway:signal:distant:form":"light",
+					"railway:signal:distant:shortened":"yes"
+				}
+			}],
 			"caption": "Ks-Vorsignal in verkürztem Bremswegabstand"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/ks-distant-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:ks",
+					"railway:signal:distant:form":"light"
+				}
+			}],
 			"caption": "Ks-Vorsignal"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/ks-main-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"DE-ESO:ks",
+					"railway:signal:main:form":"light"
+				}
+			}],
 			"caption": "Ks-Hauptsignal"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/ks-combined-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:combined":"DE-ESO:ks",
+					"railway:signal:combined:form":"light"
+				}
+			}],
 			"caption": "Ks-Mehrabschnittssignal"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/ks-combined-shortened-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:combined":"DE-ESO:ks",
+					"railway:signal:combined:form":"light",
+					"railway:signal:combined:shortened":"yes"
+				}
+			}],
 			"caption": "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/sv-sv0-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:combined":"DE-ESO:sv",
+					"railway:signal:combined:states":"DE-ESO:sv0"
+				}
+			}],
 			"caption": "Sv-Signal ohne Hp 0"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/sv-hp0-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:combined":"DE-ESO:sv",
+					"railway:signal:combined:states":"DE-ESO:hp0"
+				}
+			}],
 			"caption": "Sv-Signal mit Hp 0"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/ne1-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"DE-ESO:ne1",
+					"railway:signal:main:form":"sign",
+					"railway:signal:main:function":"entry"
+				}
+			}],
 			"caption": "Ne 1 Trapeztafel"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/so106-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:so106",
+					"railway:signal:distant:form":"sign"
+				}
+			}],
 			"caption": "So 106 Kreuztafel"
 		},
 		{
 			"minzoom": 17,
-			"icon": "icons/de/ne5-ds301-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:stop":"DE-ESO:ne5",
+					"railway:signal:stop:form":"sign"
+				}
+			}],
 			"caption": "Ne 5 Haltetafel"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/vr0-semaphore-26.png",
+			"lineheight": 28,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:vr",
+					"railway:signal:distant:form":"semaphore"
+				}
+			}],
 			"caption": "Vr-Formvorsignal ohne Angabe der Signalzustände"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/vr1-semaphore-19.png",
+			"lineheight": 28,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:vr",
+					"railway:signal:distant:form":"semaphore",
+					"railway:signal:distant:states":"DE-ESO:vr1"
+				}
+			}],
 			"caption": "Vr-Formvorsignal ohne Vr 2"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/vr2-semaphore-27.png",
+			"lineheight": 28,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:vr",
+					"railway:signal:distant:form":"semaphore",
+					"railway:signal:distant:states":"DE-ESO:vr2"
+				}
+			}],
 			"caption": "Vr-Formvorsignal mit Vr 2"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/vr0-light-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:vr",
+					"railway:signal:distant:form":"light"
+				}
+			}],
 			"caption": "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/vr1-light-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:vr",
+					"railway:signal:distant:form":"light",
+					"railway:signal:distant:states":"DE-ESO:vr1"
+				}
+			}],
 			"caption": "Vr-Lichtvorsignal ohne Vr 2"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/vr2-light-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:vr",
+					"railway:signal:distant:form":"light",
+					"railway:signal:distant:states":"DE-ESO:vr2"
+				}
+			}],
 			"caption": "Vr-Lichtvorsignal mit Vr 2"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/vr0-light-repeated-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:vr",
+					"railway:signal:distant:form":"light",
+					"railway:signal:distant:repeated":"yes"
+				}
+			}],
 			"caption": "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/vr1-light-repeated-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:vr",
+					"railway:signal:distant:form":"light",
+					"railway:signal:distant:repeated":"yes",
+					"railway:signal:distant:states":"DE-ESO:vr1"
+				}
+			}],
 			"caption": "Vr-Lichtvorsignalwiederholer ohne Vr 2"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/vr2-light-repeated-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:vr",
+					"railway:signal:distant:form":"light",
+					"railway:signal:distant:repeated":"yes",
+					"railway:signal:distant:states":"DE-ESO:vr2"
+				}
+			}],
 			"caption": "Vr-Lichtvorsignalwiederholer mit Vr 2"
 		},
 		{
 			"minzoom": 14,
-			"maxzoom": 15,
-			"icon": "icons/de/blockkennzeichen-14.png",
-			"caption": "Blockkennzeichen"
-		},
-		{
-			"minzoom": 16,
-			"icon": "icons/de/blockkennzeichen-20.png",
+			"lineheight": 20,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:train_protection":"DE-ESO:blockkennzeichen"
+				}
+			}],
 			"caption": "Blockkennzeichen"
 		},
 		{
 			"minzoom": 14,
-			"maxzoom": 16,
-			"icon": "icons/de/bue4-ds-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:whistle":"DE-ESO:db:bü4"
+				}
+			}],
 			"caption": "Bü 4 Pfeiftafel"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/bue4-ds-only-transit-21.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:whistle":"DE-ESO:db:bü4",
+					"railway:signal:ring:only_transit":"yes"
+				}
+			}],
 			"caption": "Bü 4 Pfeiftafel für durchfahrende Züge"
 		},
 		{
 			"minzoom": 14,
-			"maxzoom": 16,
-			"icon": "icons/de/pf1-dv-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:whistle":"DE-ESO:dr:pf1"
+				}
+			}],
 			"caption": "ex-Pf 1 Pfeiftafel"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/pf1-dv-only-transit-21.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:whistle":"DE-ESO:dr:pf1",
+					"railway:signal:ring:only_transit":"yes"
+				}
+			}],
 			"caption": "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
 		},
 		{
 			"minzoom": 15,
-			"maxzoom": 16,
-			"icon": "icons/de/bue5-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:ring":"DE-ESO:bü5"
+				}
+			}],
 			"caption": "Bü 5 Läutetafel"
 		},
 		{
 			"minzoom": 15,
-			"icon": "icons/de/bue5-only-transit-21.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:ring":"DE-ESO:bü5",
+					"railway:signal:ring:only_transit":"yes"
+				}
+			}],
 			"caption": "Bü 5 Läutetafel für durchfahrende Züge"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/de/ne6-24.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:station_distant":"DE-ESO:ne6",
+					"railway:signal:station_distant:form":"sign"
+				}
+			}],
 			"caption": "Ne 6 Haltepunkttafel"
 		},
 		{
 			"minzoom": 15,
-			"icon": "icons/de/bue2-ds-28.png",
+			"lineheight": 30,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:crossing_distant":"DE-ESO:bü2",
+					"railway:signal:crossing_distant:form":"sign"
+				}
+			}],
 			"caption": "Bü 2 Rautentafel"
 		},
 		{
 			"minzoom": 15,
-			"icon": "icons/de/bue2-ds-reduced-distance-28.png",
+			"lineheight": 30,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:crossing_distant":"DE-ESO:bü2",
+					"railway:signal:crossing_distant:form":"sign",
+					"railway:signal:crossing_distant:shortened":"yes"
+				}
+			}],
 			"caption": "Bü 2 Rautentafel in verkürztem Bremswegabstand"
 		},
 		{
 			"minzoom": 17,
-			"icon": "icons/de/ra11-sign-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:shunting":"DE-ESO:ra11",
+					"railway:signal:shunting:form":"sign"
+				}
+			}],
 			"caption": "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 		},
 		{
 			"minzoom": 17,
-			"icon": "icons/de/ra11-sh1-15.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:shunting":"DE-ESO:ra11",
+					"railway:signal:shunting:form":"light",
+					"railway:signal:shunting:states":"DE-ESO:ra11;DE-ESO:sh1"
+				}
+			}],
 			"caption": "Ra 11 Wartezeichen mit Sh 1"
 		},
 		{
 			"minzoom": 17,
-			"icon": "icons/de/ra11b-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:shunting":"DE-ESO:ra11b",
+					"railway:signal:shunting:form":"sign"
+				}
+			}],
 			"caption": "Ra 11b Wartezeichen"
 		},
 		{
 			"minzoom": 17,
-			"icon": "icons/de/ra10-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:shunting":"DE-ESO:ra10",
+					"railway:signal:shunting:form":"sign"
+				}
+			}],
 			"caption": "Ra 10 Rangierhalttafel / Verschubhalttafel"
 		},
 		{
@@ -281,77 +748,221 @@
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/fi/po0-new-15.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"FI:Po",
+					"railway:signal:main:form":"light"
+				}
+			}],
 			"caption": "main signal new type (aspects not given)"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/fi/po1-new-15.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"FI:Po",
+					"railway:signal:main:states":"FI:Po1",
+					"railway:signal:main:form":"light"
+				}
+			}],
 			"caption": "main signal new type with Po 1"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/fi/po2-new-15.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"FI:Po",
+					"railway:signal:main:states":"FI:Po2",
+					"railway:signal:main:form":"light"
+				}
+                       }],
 			"caption": "main signal new type with Po 2"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/fi/po0-old-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"FI:Po-v",
+					"railway:signal:main:form":"light"
+				}
+			}],
 			"caption": "main signal old type (aspects not given)"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/fi/po1-old-16.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"FI:Po-v",
+					"railway:signal:main:states":"FI:Po1",
+					"railway:signal:main:form":"light"
+				}
+			}],
 			"caption": "main signal old type with Po 1"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/fi/po2-old-16.png",
+			"features": [{
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"FI:Po-v",
+					"railway:signal:main:states":"FI:Po2",
+					"railway:signal:main:form":"light"
+				}
+                       }],
 			"caption": "main signal old type with Po 2"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/fi/eo0-new-15.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"FI:Eo",
+					"railway:signal:distant:form":"light"
+				}
+                       }],
 			"caption": "distant signal new type (aspects not given)"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/fi/eo1-new-15.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"FI:Eo",
+					"railway:signal:distant:states":"FI:Eo1",
+					"railway:signal:distant:form":"light"
+				}
+			}],
 			"caption": "distant signal new type with Eo 1"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/fi/eo2-new-15.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"FI:Eo",
+					"railway:signal:distant:states":"FI:Eo2",
+					"railway:signal:distant:form":"light"
+				}
+                       }],
 			"caption": "distant signal new type with Eo 2"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/fi/eo0-old-10.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"FI:Eo-v",
+					"railway:signal:distant:form":"light"
+				}
+			}],
 			"caption": "distant signal old type (aspects not given)"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/fi/eo1-old-10.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"FI:Eo-v",
+					"railway:signal:distant:states":"FI:Eo1",
+					"railway:signal:distant:form":"light"
+				}
+			}],
 			"caption": "distant signal old type with Eo 1"
 		},
 		{
 			"minzoom": 14,
-			"icon": "icons/fi/eo1-po1-combined-block-15.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:combined":"FI:So",
+					"railway:signal:combined:states":"FI:Eo1;FI:Po1",
+					"railway:signal:combined:form":"light"
+				}
+			}],
 			"caption": "block signal type So"
 		},
 		{
 			"minzoom": 15,
-			"icon": "icons/fi/to1-12.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:crossing":"FI:To",
+					"railway:signal:crossing:form":"light"
+				}
+			}],
 			"caption": "crossing signal type To"
 		},
 		{
 			"minzoom": 17,
-			"icon": "icons/fi/ro0-new-12.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:shunting":"FI:Ro",
+					"railway:signal:shunting:states": "FI:Ro0",
+					"railway:signal:shunting:form":"light"
+				}
+			}],
 			"caption": "shunting signal type Ro"
 		},
 		{
 			"minzoom": 17,
-			"icon": "icons/fi/lo0-12.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:minor":"FI:Lo",
+					"railway:signal:minor:states": "FI:Lo0",
+					"railway:signal:minor:form":"light"
+				}
+			}],
 			"caption": "minor signal type Lo"
 		}
 	]

--- a/styles/signals.json
+++ b/styles/signals.json
@@ -118,25 +118,20 @@
 		},
 		{
 			"minzoom": 14,
+			"lineheight": 20,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,60],
+				"coordinates": [40,60],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:main":"DE-ESO:hp",
 					"railway:signal:main:form":"semaphore",
 					"railway:signal:main:states":"DE-ESO:hp1"
-				}
-			}],
-			"caption": "Hp-Formhauptsignal ohne Hp 2"
-		},
-		{
-			"minzoom": 14,
-			"lineheight": 20,
-			"features": [{
+				}},
+				{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [60,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -145,7 +140,7 @@
 					"railway:signal:main:states":"DE-ESO:hp2"
 				}
 			}],
-			"caption": "Hp-Formhauptsignal mit Hp 2"
+			"caption": "Hp-Formhauptsignal (ohne Hp 2, mit Hp 2)"
 		},
 		{
 			"minzoom": 14,
@@ -165,22 +160,17 @@
 			"minzoom": 14,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [40,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:main":"DE-ESO:hp",
 					"railway:signal:main:form":"light",
 					"railway:signal:main:states":"DE-ESO:hp1"
-				}
-			}],
-			"caption": "Hp-Lichthauptsignal ohne Hp 2"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
+				}},
+				{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [60,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -189,27 +179,22 @@
 					"railway:signal:main:states":"DE-ESO:hp2"
 				}
 			}],
-			"caption": "Hp-Lichthauptsignal mit Hp 2"
+			"caption": "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
 		},
 		{
 			"minzoom": 17,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,60],
+				"coordinates": [40,60],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:minor":"DE-ESO:sh",
 					"railway:signal:minor:form":"semaphore"
-				}
-			}],
-			"caption": "Sh-Formsperrsignal"
-		},
-		{
-			"minzoom": 17,
-			"features": [{
+				}},
+				{
 				"type": "Point",
-				"coordinates": [50,60],
+				"coordinates": [60,60],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -218,27 +203,22 @@
 					"railway:signal:minor:height":"dwarf"
 				}
 			}],
-			"caption": "Sh-Zwerg-Formsperrsignal"
+			"caption": "Sh-Formsperrsignal (normal, Zwergsignal)"
 		},
 		{
 			"minzoom": 17,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,60],
+				"coordinates": [40,60],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:minor":"DE-ESO:sh",
 					"railway:signal:minor:form":"light"
-				}
-			}],
-			"caption": "Sh-Lichtsperrsignal"
-		},
-		{
-			"minzoom": 17,
-			"features": [{
+				}},
+				{
 				"type": "Point",
-				"coordinates": [50,60],
+				"coordinates": [60,60],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -247,11 +227,21 @@
 					"railway:signal:minor:height":"dwarf"
 				}
 			}],
-			"caption": "Sh-Zwerg-Lichtsperrsignal"
+			"caption": "Sh-Lichtsperrsignal (normal, Zwergsignal)"
 		},
 		{
 			"minzoom": 14,
-			"features": [{
+			"features": [
+				{
+				"type": "Point",
+				"coordinates": [30,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:ks",
+					"railway:signal:distant:form":"light"
+				}},
+				{
 				"type": "Point",
 				"coordinates": [50,50],
 				"properties": {
@@ -260,15 +250,10 @@
 					"railway:signal:distant":"DE-ESO:ks",
 					"railway:signal:distant:form":"light",
 					"railway:signal:distant:repeated":"yes"
-				}
-			}],
-			"caption": "Ks-Vorsignalwiederholer"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
+				}},
+				{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [70,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -277,21 +262,7 @@
 					"railway:signal:distant:shortened":"yes"
 				}
 			}],
-			"caption": "Ks-Vorsignal in verkürztem Bremswegabstand"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
-				"type": "Point",
-				"coordinates": [50,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:distant":"DE-ESO:ks",
-					"railway:signal:distant:form":"light"
-				}
-			}],
-			"caption": "Ks-Vorsignal"
+			"caption": "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
 		},
 		{
 			"minzoom": 14,
@@ -309,52 +280,44 @@
 		},
 		{
 			"minzoom": 14,
-			"features": [{
+			"features": [
+				{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [40,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:combined":"DE-ESO:ks",
 					"railway:signal:combined:form":"light"
-				}
-			}],
-			"caption": "Ks-Mehrabschnittssignal"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
+				}},
+				{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [60,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:combined":"DE-ESO:ks",
 					"railway:signal:combined:form":"light",
 					"railway:signal:combined:shortened":"yes"
-				}
-			}],
-			"caption": "Ks-Mehrabschnittssignal in verkürztem Bremswegabstand"
+				}}
+			],
+			"caption": "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
 		},
 		{
 			"minzoom": 14,
-			"features": [{
+			"features": [
+				{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [40,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:combined":"DE-ESO:sv",
 					"railway:signal:combined:states":"DE-ESO:sv0"
-				}
-			}],
-			"caption": "Sv-Signal ohne Hp 0"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
+				}},
+				{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [60,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -362,7 +325,7 @@
 					"railway:signal:combined:states":"DE-ESO:hp0"
 				}
 			}],
-			"caption": "Sv-Signal mit Hp 0"
+			"caption": "Sv-Signal (ohne Hp 0, mit Hp 0)"
 		},
 		{
 			"minzoom": 14,
@@ -427,23 +390,17 @@
 			"lineheight": 28,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [40,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:distant":"DE-ESO:vr",
 					"railway:signal:distant:form":"semaphore",
 					"railway:signal:distant:states":"DE-ESO:vr1"
-				}
-			}],
-			"caption": "Vr-Formvorsignal ohne Vr 2"
-		},
-		{
-			"minzoom": 14,
-			"lineheight": 28,
-			"features": [{
+				}},
+				{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [60,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -452,57 +409,22 @@
 					"railway:signal:distant:states":"DE-ESO:vr2"
 				}
 			}],
-			"caption": "Vr-Formvorsignal mit Vr 2"
+			"caption": "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
 		},
 		{
 			"minzoom": 14,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [35,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:distant":"DE-ESO:vr",
 					"railway:signal:distant:form":"light"
-				}
-			}],
-			"caption": "Vr-Lichtvorsignal ohne Angabe der Signalzustände"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
+				}},
+				{
 				"type": "Point",
-				"coordinates": [50,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:distant":"DE-ESO:vr",
-					"railway:signal:distant:form":"light",
-					"railway:signal:distant:states":"DE-ESO:vr1"
-				}
-			}],
-			"caption": "Vr-Lichtvorsignal ohne Vr 2"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
-				"type": "Point",
-				"coordinates": [50,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:distant":"DE-ESO:vr",
-					"railway:signal:distant:form":"light",
-					"railway:signal:distant:states":"DE-ESO:vr2"
-				}
-			}],
-			"caption": "Vr-Lichtvorsignal mit Vr 2"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
-				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [65,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -511,13 +433,23 @@
 					"railway:signal:distant:repeated":"yes"
 				}
 			}],
-			"caption": "Vr-Lichtvorsignalwiederholer ohne Angabe der Signalzustände"
+			"caption": "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/verkürzter Bremswegabstand)"
 		},
 		{
 			"minzoom": 14,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [35,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:vr",
+					"railway:signal:distant:form":"light",
+					"railway:signal:distant:states":"DE-ESO:vr1"
+				}},
+				{
+				"type": "Point",
+				"coordinates": [65,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -527,13 +459,23 @@
 					"railway:signal:distant:states":"DE-ESO:vr1"
 				}
 			}],
-			"caption": "Vr-Lichtvorsignalwiederholer ohne Vr 2"
+			"caption": "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
 		},
 		{
 			"minzoom": 14,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [35,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:vr",
+					"railway:signal:distant:form":"light",
+					"railway:signal:distant:states":"DE-ESO:vr2"
+				}},
+				{
+				"type": "Point",
+				"coordinates": [65,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -543,7 +485,7 @@
 					"railway:signal:distant:states":"DE-ESO:vr2"
 				}
 			}],
-			"caption": "Vr-Lichtvorsignalwiederholer mit Vr 2"
+			"caption": "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
 		},
 		{
 			"minzoom": 14,
@@ -561,22 +503,18 @@
 		},
 		{
 			"minzoom": 14,
+			"lineheight": 20,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [40,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:whistle":"DE-ESO:db:bü4"
-				}
-			}],
-			"caption": "Bü 4 Pfeiftafel"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
+				}},
+				{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [60,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -584,26 +522,22 @@
 					"railway:signal:ring:only_transit":"yes"
 				}
 			}],
-			"caption": "Bü 4 Pfeiftafel für durchfahrende Züge"
+			"caption": "Bü 4 Pfeiftafel (normal, für durchfahrende Züge)"
 		},
 		{
 			"minzoom": 14,
+			"lineheight": 20,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [40,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:whistle":"DE-ESO:dr:pf1"
-				}
-			}],
-			"caption": "ex-Pf 1 Pfeiftafel"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
+				}},
+				{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [60,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -611,26 +545,22 @@
 					"railway:signal:ring:only_transit":"yes"
 				}
 			}],
-			"caption": "ex-Pf 1 Pfeiftafel für durchfahrende Züge"
+			"caption": "ex-Pf 1 Pfeiftafel (normal, für durchfahrende Züge)"
 		},
 		{
 			"minzoom": 15,
+			"lineheight": 20,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [40,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:ring":"DE-ESO:bü5"
-				}
-			}],
-			"caption": "Bü 5 Läutetafel"
-		},
-		{
-			"minzoom": 15,
-			"features": [{
+				}},
+				{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [60,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -638,7 +568,7 @@
 					"railway:signal:ring:only_transit":"yes"
 				}
 			}],
-			"caption": "Bü 5 Läutetafel für durchfahrende Züge"
+			"caption": "Bü 5 Läutetafel (normal, für durchfahrende Züge)"
 		},
 		{
 			"minzoom": 14,
@@ -659,22 +589,16 @@
 			"lineheight": 30,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [40,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:crossing_distant":"DE-ESO:bü2",
 					"railway:signal:crossing_distant:form":"sign"
-				}
-			}],
-			"caption": "Bü 2 Rautentafel"
-		},
-		{
-			"minzoom": 15,
-			"lineheight": 30,
-			"features": [{
+				}},
+				{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [60,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -683,7 +607,7 @@
 					"railway:signal:crossing_distant:shortened":"yes"
 				}
 			}],
-			"caption": "Bü 2 Rautentafel in verkürztem Bremswegabstand"
+			"caption": "Bü 2 Rautentafel (normal, verkürzter Bremswegabstand)"
 		},
 		{
 			"minzoom": 17,
@@ -750,51 +674,16 @@
 			"minzoom": 14,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,60],
+				"coordinates": [40,60],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:main":"FI:Po",
 					"railway:signal:main:form":"light"
-				}
-			}],
-			"caption": "main signal new type (aspects not given)"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
+				}},
+				{
 				"type": "Point",
-				"coordinates": [50,60],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:main":"FI:Po",
-					"railway:signal:main:states":"FI:Po1",
-					"railway:signal:main:form":"light"
-				}
-			}],
-			"caption": "main signal new type with Po 1"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
-				"type": "Point",
-				"coordinates": [50,60],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:main":"FI:Po",
-					"railway:signal:main:states":"FI:Po2",
-					"railway:signal:main:form":"light"
-				}
-                       }],
-			"caption": "main signal new type with Po 2"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
-				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [60,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -802,13 +691,23 @@
 					"railway:signal:main:form":"light"
 				}
 			}],
-			"caption": "main signal old type (aspects not given)"
+			"caption": "main signal without aspects given (new type, old type)"
 		},
 		{
 			"minzoom": 14,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,50],
+				"coordinates": [40,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"FI:Po",
+					"railway:signal:main:states":"FI:Po1",
+					"railway:signal:main:form":"light"
+				}},
+				{
+				"type": "Point",
+				"coordinates": [60,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -817,12 +716,23 @@
 					"railway:signal:main:form":"light"
 				}
 			}],
-			"caption": "main signal old type with Po 1"
+			"caption": "main signal with Po 1 (new type, old type)"
 		},
 		{
 			"minzoom": 14,
 			"features": [{
-				"coordinates": [50,50],
+				"type": "Point",
+				"coordinates": [40,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"FI:Po",
+					"railway:signal:main:states":"FI:Po2",
+					"railway:signal:main:form":"light"
+				}},
+				{
+				"type": "Point",
+				"coordinates": [60,50],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
@@ -830,37 +740,56 @@
 					"railway:signal:main:states":"FI:Po2",
 					"railway:signal:main:form":"light"
 				}
-                       }],
-			"caption": "main signal old type with Po 2"
+			}],
+			"caption": "main signal with Po 2 (new type, old type)"
 		},
 		{
 			"minzoom": 14,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,60],
+				"coordinates": [40,60],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:distant":"FI:Eo",
 					"railway:signal:distant:form":"light"
+				}},
+				{
+				"type": "Point",
+				"coordinates": [60,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"FI:Eo-v",
+					"railway:signal:distant:form":"light"
 				}
-                       }],
-			"caption": "distant signal new type (aspects not given)"
+			}],
+			"caption": "distant signal without aspects given (new type, old type)"
 		},
 		{
 			"minzoom": 14,
 			"features": [{
 				"type": "Point",
-				"coordinates": [50,60],
+				"coordinates": [40,60],
 				"properties": {
 					"railway":"signal",
 					"railway:signal:direction":"forward",
 					"railway:signal:distant":"FI:Eo",
 					"railway:signal:distant:states":"FI:Eo1",
 					"railway:signal:distant:form":"light"
+				}},
+				{
+				"type": "Point",
+				"coordinates": [60,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"FI:Eo-v",
+					"railway:signal:distant:states":"FI:Eo1",
+					"railway:signal:distant:form":"light"
 				}
 			}],
-			"caption": "distant signal new type with Eo 1"
+			"caption": "distant signal with Eo 1 (new type, old type)"
 		},
 		{
 			"minzoom": 14,
@@ -874,37 +803,8 @@
 					"railway:signal:distant:states":"FI:Eo2",
 					"railway:signal:distant:form":"light"
 				}
-                       }],
-			"caption": "distant signal new type with Eo 2"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
-				"type": "Point",
-				"coordinates": [50,60],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:distant":"FI:Eo-v",
-					"railway:signal:distant:form":"light"
-				}
 			}],
-			"caption": "distant signal old type (aspects not given)"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
-				"type": "Point",
-				"coordinates": [50,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:distant":"FI:Eo-v",
-					"railway:signal:distant:states":"FI:Eo1",
-					"railway:signal:distant:form":"light"
-				}
-			}],
-			"caption": "distant signal old type with Eo 1"
+			"caption": "distant signal with Eo 2 (new type)"
 		},
 		{
 			"minzoom": 14,

--- a/styles/signals.json
+++ b/styles/signals.json
@@ -144,234 +144,6 @@
 		},
 		{
 			"minzoom": 14,
-			"features": [{
-				"type": "Point",
-				"coordinates": [50,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:main":"DE-ESO:hp",
-					"railway:signal:main:form":"light"
-				}
-			}],
-			"caption": "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
-				"type": "Point",
-				"coordinates": [40,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:main":"DE-ESO:hp",
-					"railway:signal:main:form":"light",
-					"railway:signal:main:states":"DE-ESO:hp1"
-				}},
-				{
-				"type": "Point",
-				"coordinates": [60,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:main":"DE-ESO:hp",
-					"railway:signal:main:form":"light",
-					"railway:signal:main:states":"DE-ESO:hp2"
-				}
-			}],
-			"caption": "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
-		},
-		{
-			"minzoom": 17,
-			"features": [{
-				"type": "Point",
-				"coordinates": [40,60],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:minor":"DE-ESO:sh",
-					"railway:signal:minor:form":"semaphore"
-				}},
-				{
-				"type": "Point",
-				"coordinates": [60,60],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:minor":"DE-ESO:sh",
-					"railway:signal:minor:form":"semaphore",
-					"railway:signal:minor:height":"dwarf"
-				}
-			}],
-			"caption": "Sh-Formsperrsignal (normal, Zwergsignal)"
-		},
-		{
-			"minzoom": 17,
-			"features": [{
-				"type": "Point",
-				"coordinates": [40,60],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:minor":"DE-ESO:sh",
-					"railway:signal:minor:form":"light"
-				}},
-				{
-				"type": "Point",
-				"coordinates": [60,60],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:minor":"DE-ESO:sh",
-					"railway:signal:minor:form":"light",
-					"railway:signal:minor:height":"dwarf"
-				}
-			}],
-			"caption": "Sh-Lichtsperrsignal (normal, Zwergsignal)"
-		},
-		{
-			"minzoom": 14,
-			"features": [
-				{
-				"type": "Point",
-				"coordinates": [30,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:distant":"DE-ESO:ks",
-					"railway:signal:distant:form":"light"
-				}},
-				{
-				"type": "Point",
-				"coordinates": [50,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:distant":"DE-ESO:ks",
-					"railway:signal:distant:form":"light",
-					"railway:signal:distant:repeated":"yes"
-				}},
-				{
-				"type": "Point",
-				"coordinates": [70,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:distant":"DE-ESO:ks",
-					"railway:signal:distant:form":"light",
-					"railway:signal:distant:shortened":"yes"
-				}
-			}],
-			"caption": "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
-				"type": "Point",
-				"coordinates": [50,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:main":"DE-ESO:ks",
-					"railway:signal:main:form":"light"
-				}
-			}],
-			"caption": "Ks-Hauptsignal"
-		},
-		{
-			"minzoom": 14,
-			"features": [
-				{
-				"type": "Point",
-				"coordinates": [40,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:combined":"DE-ESO:ks",
-					"railway:signal:combined:form":"light"
-				}},
-				{
-				"type": "Point",
-				"coordinates": [60,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:combined":"DE-ESO:ks",
-					"railway:signal:combined:form":"light",
-					"railway:signal:combined:shortened":"yes"
-				}}
-			],
-			"caption": "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
-		},
-		{
-			"minzoom": 14,
-			"features": [
-				{
-				"type": "Point",
-				"coordinates": [40,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:combined":"DE-ESO:sv",
-					"railway:signal:combined:states":"DE-ESO:sv0"
-				}},
-				{
-				"type": "Point",
-				"coordinates": [60,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:combined":"DE-ESO:sv",
-					"railway:signal:combined:states":"DE-ESO:hp0"
-				}
-			}],
-			"caption": "Sv-Signal (ohne Hp 0, mit Hp 0)"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
-				"type": "Point",
-				"coordinates": [50,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:main":"DE-ESO:ne1",
-					"railway:signal:main:form":"sign",
-					"railway:signal:main:function":"entry"
-				}
-			}],
-			"caption": "Ne 1 Trapeztafel"
-		},
-		{
-			"minzoom": 14,
-			"features": [{
-				"type": "Point",
-				"coordinates": [50,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:distant":"DE-ESO:so106",
-					"railway:signal:distant:form":"sign"
-				}
-			}],
-			"caption": "So 106 Kreuztafel"
-		},
-		{
-			"minzoom": 17,
-			"features": [{
-				"type": "Point",
-				"coordinates": [50,50],
-				"properties": {
-					"railway":"signal",
-					"railway:signal:direction":"forward",
-					"railway:signal:stop":"DE-ESO:ne5",
-					"railway:signal:stop:form":"sign"
-				}
-			}],
-			"caption": "Ne 5 Haltetafel"
-		},
-		{
-			"minzoom": 14,
 			"lineheight": 28,
 			"features": [{
 				"type": "Point",
@@ -410,6 +182,45 @@
 				}
 			}],
 			"caption": "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
+		},
+		{
+			"minzoom": 14,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"DE-ESO:hp",
+					"railway:signal:main:form":"light"
+				}
+			}],
+			"caption": "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
+		},
+		{
+			"minzoom": 14,
+			"features": [{
+				"type": "Point",
+				"coordinates": [40,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"DE-ESO:hp",
+					"railway:signal:main:form":"light",
+					"railway:signal:main:states":"DE-ESO:hp1"
+				}},
+				{
+				"type": "Point",
+				"coordinates": [60,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"DE-ESO:hp",
+					"railway:signal:main:form":"light",
+					"railway:signal:main:states":"DE-ESO:hp2"
+				}
+			}],
+			"caption": "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
 		},
 		{
 			"minzoom": 14,
@@ -486,6 +297,195 @@
 				}
 			}],
 			"caption": "Vr-Lichtvorsignal mit Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
+		},
+		{
+			"minzoom": 14,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"DE-ESO:ks",
+					"railway:signal:main:form":"light"
+				}
+			}],
+			"caption": "Ks-Hauptsignal"
+		},
+		{
+			"minzoom": 14,
+			"features": [
+				{
+				"type": "Point",
+				"coordinates": [40,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:combined":"DE-ESO:ks",
+					"railway:signal:combined:form":"light"
+				}},
+				{
+				"type": "Point",
+				"coordinates": [60,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:combined":"DE-ESO:ks",
+					"railway:signal:combined:form":"light",
+					"railway:signal:combined:shortened":"yes"
+				}}
+			],
+			"caption": "Ks-Mehrabschnittssignal (normal, verkürzter Bremswegabstand)"
+		},
+		{
+			"minzoom": 14,
+			"features": [
+				{
+				"type": "Point",
+				"coordinates": [30,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:ks",
+					"railway:signal:distant:form":"light"
+				}},
+				{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:ks",
+					"railway:signal:distant:form":"light",
+					"railway:signal:distant:repeated":"yes"
+				}},
+				{
+				"type": "Point",
+				"coordinates": [70,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:ks",
+					"railway:signal:distant:form":"light",
+					"railway:signal:distant:shortened":"yes"
+				}
+			}],
+			"caption": "Ks-Vorsignal (normal, Wiederholer, verkürzter Bremswegabstand)"
+		},
+		{
+			"minzoom": 14,
+			"features": [
+				{
+				"type": "Point",
+				"coordinates": [40,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:combined":"DE-ESO:sv",
+					"railway:signal:combined:states":"DE-ESO:sv0"
+				}},
+				{
+				"type": "Point",
+				"coordinates": [60,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:combined":"DE-ESO:sv",
+					"railway:signal:combined:states":"DE-ESO:hp0"
+				}
+			}],
+			"caption": "Sv-Signal (ohne Hp 0, mit Hp 0)"
+		},
+		{
+			"minzoom": 17,
+			"features": [{
+				"type": "Point",
+				"coordinates": [40,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:minor":"DE-ESO:sh",
+					"railway:signal:minor:form":"semaphore"
+				}},
+				{
+				"type": "Point",
+				"coordinates": [60,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:minor":"DE-ESO:sh",
+					"railway:signal:minor:form":"semaphore",
+					"railway:signal:minor:height":"dwarf"
+				}
+			}],
+			"caption": "Sh-Formsperrsignal (normal, Zwergsignal)"
+		},
+		{
+			"minzoom": 17,
+			"features": [{
+				"type": "Point",
+				"coordinates": [40,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:minor":"DE-ESO:sh",
+					"railway:signal:minor:form":"light"
+				}},
+				{
+				"type": "Point",
+				"coordinates": [60,60],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:minor":"DE-ESO:sh",
+					"railway:signal:minor:form":"light",
+					"railway:signal:minor:height":"dwarf"
+				}
+			}],
+			"caption": "Sh-Lichtsperrsignal (normal, Zwergsignal)"
+		},
+		{
+			"minzoom": 14,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:main":"DE-ESO:ne1",
+					"railway:signal:main:form":"sign",
+					"railway:signal:main:function":"entry"
+				}
+			}],
+			"caption": "Ne 1 Trapeztafel"
+		},
+		{
+			"minzoom": 14,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:distant":"DE-ESO:so106",
+					"railway:signal:distant:form":"sign"
+				}
+			}],
+			"caption": "So 106 Kreuztafel"
+		},
+		{
+			"minzoom": 17,
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"signal",
+					"railway:signal:direction":"forward",
+					"railway:signal:stop":"DE-ESO:ne5",
+					"railway:signal:stop:form":"sign"
+				}
+			}],
+			"caption": "Ne 5 Haltetafel"
 		},
 		{
 			"minzoom": 14,

--- a/styles/standard.json
+++ b/styles/standard.json
@@ -8,27 +8,81 @@
 		},
 		{
 			"minzoom": 10,
-			"symbol": "<g fill=\"none\" stroke=\"#797979\" stroke-width=\"10.5\"><path stroke-linecap=\"butt\" d=\"M9 8 l24 0\" /></g><g fill=\"none\" stroke=\"black\" stroke-width=\"3.5\"><path stroke-linecap=\"round\" d=\"M5 8 l32 0\" /></g>",
+			"features": [
+				{"type": "LineString",
+				"coordinates": [[10,50],[20,50]],
+				"properties": {
+					"railway":"rail"
+				}},
+				{"type": "LineString",
+				"coordinates": [[20,50],[50,50]],
+				"properties": {
+					"bridge":"yes",
+					"railway":"rail"
+				}},
+				{"type": "LineString",
+				"coordinates": [[50,50],[60,50]],
+				"properties": {
+					"railway":"rail"
+				}}
+			],
 			"caption": "Bridge"
 		},
 		{
 			"minzoom": 10,
-			"symbol": "<g fill=\"none\" stroke=\"black\" stroke-width=\"3.5\"><path stroke-linecap=\"round\" d=\"M5 8 l32 0\" /></g><g fill=\"none\" stroke=\"white\" stroke-width=\"6\"><path stroke-linecap=\"butt\" opacity=\"0.6\" d=\"M9 8 l24 0\" /></g>",
+			"features": [
+				{"type": "LineString",
+				"coordinates": [[10,50],[20,50]],
+				"properties": {
+					"railway":"rail"
+				}},
+				{"type": "LineString",
+				"coordinates": [[20,50],[50,50]],
+				"properties": {
+					"railway":"rail",
+					"tunnel":"yes"
+				}},
+				{"type": "LineString",
+				"coordinates": [[50,50],[60,50]],
+				"properties": {
+					"railway":"rail"
+				}}
+			],
 			"caption": "Tunnel"
 		},
 		{
 			"minzoom": 2,
-			"symbol": "<g fill=\"none\" stroke=\"black\" stroke-width=\"2.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g><text x=\"2\" y=\"12\" style=\"font-family: Verdana; font-weight: bold; font-size: 12px; fill: #585858; stroke: white; stroke-width: 0.5;\">2610</text>",
+			"features": [
+				{"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"railway":"rail",
+					"usage":"main",
+					"ref":1761
+				}}
+			],
 			"caption": "Line ref"
 		},
 		{
 			"minzoom": 10,
-			"symbol": "<g fill=\"none\" stroke=\"black\" stroke-width=\"2.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [
+				{"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"railway":"rail"
+				}}
+			],
 			"caption": "Railroad line"
 		},
 		{
-			"minzoom": 10,
-			"symbol": "<g fill=\"none\" stroke=\"black\" stroke-width=\"1.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g><g fill=\"none\" stroke=\"black\" stroke-width=\"4.5\"><path stroke-linecap=\"butt\" stroke-dasharray=\"3,3\" d=\"M5 8 l32 0\" /></g>",
+			"minzoom": 9,
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"railway":"narrow_gauge"
+				}
+			}],
 			"caption": "Narrow gauge track"
 		},
 		{
@@ -37,148 +91,274 @@
 		},
 		{
 			"minzoom": 10,
-			"symbol": "<g fill=\"none\" stroke=\"black\" stroke-width=\"2\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g><text x=\"17\" y=\"13\" style=\"font-family: Arial; font-size: 12px; fill: gray; stroke: #cccccc; stroke-width: 0.5;\">7</text>",
+			"features": [
+				{"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"railway":"rail",
+					"railway:track_ref":7,
+					"service":"siding"
+				}}
+			],
 			"caption": "Siding"
 		},
 		{
 			"minzoom": 10,
-			"symbol": "<g fill=\"none\" stroke=\"black\" stroke-width=\"1.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g><text x=\"17\" y=\"13\" style=\"font-family: Arial; font-size: 12px; fill: gray; stroke: #cccccc; stroke-width: 0.5;\">7</text>",
+			"features": [
+				{"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"railway":"rail",
+					"railway:track_ref":7,
+					"service":"yard"
+				}}
+			],
 			"caption": "Yard track"
 		},
 		{
 			"minzoom": 10,
-			"symbol": "<g fill=\"none\" stroke=\"#87491D\" stroke-width=\"3\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"railway":"rail",
+					"service":"spur"
+				}
+			}],
 			"caption": "Spur"
 		},
 		{
 			"minzoom": 10,
-			"symbol": "<g fill=\"none\" stroke=\"black\" stroke-width=\"1\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"railway":"rail",
+					"service":"crossover"
+				}
+			}],
 			"caption": "Crossover track"
 		},
 		{
 			"minzoom": 2,
-			"maxzoom": 5,
-			"symbol": "<g fill=\"none\" stroke=\"#DACA00\" stroke-width=\"1.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
-			"caption": "Branch line"
-		},
-		{
-			"minzoom": 6,
-			"maxzoom": 8,
-			"symbol": "<g fill=\"none\" stroke=\"#DACA00\" stroke-width=\"2.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
-			"caption": "Branch line"
-		},
-		{
-			"minzoom": 9,
-			"symbol": "<g fill=\"none\" stroke=\"#DACA00\" stroke-width=\"3.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"railway":"rail",
+					"usage":"branch"
+				}
+			}],
 			"caption": "Branch line"
 		},
 		{
 			"minzoom": 2,
-			"maxzoom": 5,
-			"symbol": "<g fill=\"none\" stroke=\"#FF8100\" stroke-width=\"1.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
-			"caption": "Main line"
-		},
-		{
-			"minzoom": 6,
-			"maxzoom": 8,
-			"symbol": "<g fill=\"none\" stroke=\"#FF8100\" stroke-width=\"2.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
-			"caption": "Main line"
-		},
-		{
-			"minzoom": 9,
-			"symbol": "<g fill=\"none\" stroke=\"#FF8100\" stroke-width=\"3.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"railway":"rail",
+					"usage":"main"
+				}
+			}],
 			"caption": "Main line"
 		},
 		{
 			"minzoom": 2,
-			"maxzoom": 5,
-			"symbol": "<g fill=\"none\" stroke=\"#FF0C00\" stroke-width=\"1.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
-			"caption": "Highspeed line"
-		},
-		{
-			"minzoom": 6,
-			"maxzoom": 8,
-			"symbol": "<g fill=\"none\" stroke=\"#FF0C00\" stroke-width=\"2.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
-			"caption": "Highspeed line"
-		},
-		{
-			"minzoom": 9,
-			"symbol": "<g fill=\"none\" stroke=\"#FF0C00\" stroke-width=\"3.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"highspeed":"yes",
+					"railway":"rail",
+					"usage":"main"
+				}
+			}],
 			"caption": "Highspeed line"
 		},
 		{
 			"minzoom": 10,
-			"symbol": "<g fill=\"none\" stroke=\"#87491D\" stroke-width=\"2\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"railway":"rail",
+					"usage":"industrial"
+				}
+			}],
 			"caption": "Industrial line"
 		},
 		{
 			"minzoom": 10,
-			"symbol": "<g fill=\"none\" stroke=\"#87491D\" stroke-width=\"1.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"railway":"rail",
+					"service":"yard",
+					"usage":"industrial"
+				}
+			}],
 			"caption": "Industrial service track"
 		},
 		{
 			"minzoom": 9,
-			"symbol": "<g fill=\"none\" stroke=\"#70584D\" stroke-width=\"2\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g><g fill=\"none\" stroke=\"#70584D\" stroke-width=\"6\"><path stroke-linecap=\"butt\" stroke-dasharray=\"3,10\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"railway":"preserved"
+				}
+			}],
 			"caption": "Preserved track"
 		},
 		{
 			"minzoom": 9,
-			"symbol": "<g fill=\"none\" stroke=\"black\" stroke-width=\"3\"><path stroke-linecap=\"butt\" stroke-dasharray=\"9,9\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"construction:railway":"rail",
+					"railway":"construction"
+				}
+			}],
 			"caption": "Track under construction"
 		},
 		{
 			"minzoom": 9,
-			"symbol": "<g fill=\"none\" stroke=\"black\" stroke-width=\"3\"><path stroke-linecap=\"round\" stroke-dasharray=\"2,8\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"proposed:railway":"rail",
+					"railway":"proposed"
+				}
+			}],
 			"caption": "Proposed track"
 		},
 		{
 			"minzoom": 9,
-			"symbol": "<g fill=\"none\" stroke=\"black\" stroke-width=\"4\"><path stroke-linecap=\"butt\" opacity=\"0.2\" d=\"M5 8 l32 0\" /></g><g fill=\"none\" stroke=\"#70584D\" stroke-width=\"3\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"disused:railway":"rail",
+					"railway":"disused"
+				}
+			}],
 			"caption": "Disused track"
 		},
 		{
 			"minzoom": 9,
-			"symbol": "<g fill=\"none\" stroke=\"black\" stroke-width=\"4\"><path stroke-linecap=\"butt\" stroke-dasharray=\"5,5\" opacity=\"0.2\" d=\"M5 8 l32 0\" /></g><g fill=\"none\" stroke=\"#70584D\" stroke-width=\"3\"><path stroke-linecap=\"round\" stroke-dasharray=\"5,5\" opacity=\"0.8\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"abandoned:railway":"rail",
+					"railway":"abandoned"
+				}
+			}],
 			"caption": "Abandoned track"
 		},
 		{
 			"minzoom": 9,
-			"symbol": "<g fill=\"none\" stroke=\"black\" stroke-width=\"4\"><path stroke-linecap=\"butt\" stroke-dasharray=\"3,7\" opacity=\"0.2\" d=\"M5 8 l32 0\" /></g><g fill=\"none\" stroke=\"#70584D\" stroke-width=\"3\"><path stroke-linecap=\"round\" stroke-dasharray=\"3,7\" opacity=\"0.6\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"razed:railway":"rail",
+					"railway":"razed"
+				}
+			}],
 			"caption": "Razed track"
 		},
 		{
 			"minzoom": 11,
-			"symbol": "<g fill=\"none\" stroke=\"#D877B8\" stroke-width=\"2.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"railway":"tram"
+				}
+			}],
 			"caption": "Tram"
 		},
 		{
 			"minzoom": 10,
-			"symbol": "<g fill=\"none\" stroke=\"#0300C3\" stroke-width=\"2.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [
+				{"type": "LineString",
+				"coordinates": [[10,50],[20,50]],
+				"properties": {
+					"railway":"subway"
+				}},
+				{"type": "LineString",
+				"coordinates": [[20,50],[60,50]],
+				"properties": {
+					"railway":"subway",
+					"tunnel":"yes"
+				}}
+			],
 			"caption": "Subway"
 		},
 		{
 			"minzoom": 10,
-			"symbol": "<g fill=\"none\" stroke=\"#00BD14\" stroke-width=\"2.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l32 0\" /></g>",
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[60,50]],
+				"properties": {
+					"railway":"light_rail"
+				}
+			}],
 			"caption": "Light rail"
 		},
 		{
 			"minzoom": 16,
-			"symbol": "<text x=\"0\" y=\"12\" style=\"font-family: Arial; font-size: 12px; fill: black; font-weight: bold; stroke: white; stroke-width: 0.5;\">W23</text>",
+			"features": [{
+				"type": "Point",
+				"coordinates": [30,50],
+				"properties": {
+					"railway":"switch",
+					"ref":"W23"
+				}
+			}],
 			"caption": "Switch (remote-controlled)"
 		},
 		{
 			"minzoom": 16,
-			"symbol": "<text x=\"0\" y=\"12\" style=\"font-family: Arial; font-size: 12px; fill: black; font-weight: bold; stroke: yellow; stroke-width: 0.5;\">W23</text>",
+			"features": [{
+				"type": "Point",
+				"coordinates": [30,50],
+				"properties": {
+					"railway":"switch",
+					"railway:local_operated":"yes",
+					"ref":"W23"
+				}
+			}],
 			"caption": "Switch (local operated)"
 		},
 		{
 			"minzoom": 16,
-			"symbol": "<text x=\"0\" y=\"12\" style=\"font-family: Arial; font-size: 12px; fill: black; font-weight: bold; stroke: orange; stroke-width: 0.5;\">W23</text>",
+			"features": [{
+				"type": "Point",
+				"coordinates": [30,50],
+				"properties": {
+					"railway":"switch",
+					"railway:switch:resetting":"yes",
+					"ref":"W23"
+				}
+			}],
 			"caption": "Resetting switch"
 		},
 		{
 			"minzoom": 11,
-			"symbol": "<text x=\"0\" y=\"12\" style=\"font-family: Arial Black; font-size: 12px; fill: black; font-weight: bold; stroke: white; stroke-width: 0.5;\">26.4</text>",
+			"features": [{
+				"type": "Point",
+				"coordinates": [30,50],
+				"properties": {
+					"railway":"milestone",
+					"railway:position":26.4
+				}
+			}],
 			"caption": "Milestone"
 		},
 		{
@@ -187,62 +367,77 @@
 		},
 		{
 			"minzoom": 8,
-			"maxzoom": 11,
-			"symbol": "<text x=\"0\" y=\"13\" style=\"font-family: Arial Black; font-size: 14px; fill: blue; font-weight: bold; stroke: white; stroke-width: 1.5;\">KB</text>",
-			"caption": "Station"
-		},
-		{
-			"minzoom": 12,
-			"symbol": "<text x=\"0\" y=\"13\" style=\"font-family: Arial Black; font-size: 14px; fill: blue; font-weight: bold; stroke: white; stroke-width: 1.5;\">Bonn Hbf</text>",
+			"features": [{
+				"type": "Point",
+				"coordinates": [40,50],
+				"properties": {
+					"railway":"station",
+					"railway:ref":"KB",
+					"name":"Bonn Hbf"
+				}
+			}],
 			"caption": "Station"
 		},
 		{
 			"minzoom": 8,
-			"maxzoom": 11,
-			"symbol": "<text x=\"0\" y=\"13\" style=\"font-family: Arial Black; font-size: 14px; fill: #87491D; font-weight: bold; stroke: #F1F1F1; stroke-width: 1.5;\">KNG</text>",
-			"caption": "Yard"
-		},
-		{
-			"minzoom": 12,
-			"symbol": "<text x=\"0\" y=\"13\" style=\"font-family: Arial Black; font-size: 14px; fill: #87491D; font-weight: bold; stroke: #F1F1F1; stroke-width: 1.5;\">Neuss Gbf</text>",
+			"features": [{
+				"type": "Point",
+				"coordinates": [40,50],
+				"properties": {
+					"railway":"yard",
+					"railway:ref":"KNG",
+					"name":"Neuss Gbf"
+				}
+			}],
 			"caption": "Yard"
 		},
 		{
 			"minzoom": 10,
-			"maxzoom": 11,
-			"symbol": "<text x=\"0\" y=\"13\" style=\"font-family: Arial Black; font-size: 14px; fill: blue; stroke: white; stroke-width: 1.5;\">KANM</text>",
-			"caption": "Halt"
-		},
-		{
-			"minzoom": 12,
-			"symbol": "<text x=\"0\" y=\"13\" style=\"font-family: Arial Black; font-size: 14px; fill: blue; stroke: white; stroke-width: 1.5;\">Angermund</text>",
+			"features": [{
+				"type": "Point",
+				"coordinates": [40,50],
+				"properties": {
+					"railway":"halt",
+					"railway:ref":"HLEM",
+					"name":"Lemmie"
+				}
+			}],
 			"caption": "Halt"
 		},
 		{
 			"minzoom": 8,
-			"maxzoom": 11,
-			"symbol": "<text x=\"0\" y=\"13\" style=\"font-family: Arial Black; font-size: 14px; fill: #616161; stroke: #F1F1F1; stroke-width: 1.5;\">KWEB</text>",
-			"caption": "Junction, Crossover, Service Station, Site"
-		},
-		{
-			"minzoom": 12,
-			"symbol": "<text x=\"0\" y=\"13\" style=\"font-family: Arial Black; font-size: 14px; fill: #616161; stroke: #F1F1F1; stroke-width: 1.5;\">Lohbruch</text>",
+			"features": [{
+				"type": "Point",
+				"coordinates": [40,50],
+				"properties": {
+					"railway":"service_station",
+					"railway:ref":"KWEB",
+					"name":"Lohbruch"
+				}
+			}],
 			"caption": "Junction, Crossover, Service Station, Site"
 		},
 		{
 			"minzoom": 13,
-			"maxzoom": 13,
-			"icon": "icons/tramstop.png",
-			"caption": "Tram stop"
-		},
-		{
-			"minzoom": 14,
-			"symbol": "<text x=\"0\" y=\"13\" style=\"font-family: Arial; font-size: 13px; fill: #D877B8; font-weight: bold; stroke: white; stroke-width: 0.5;\">Grundend</text>",
+			"features": [{
+				"type": "Point",
+				"coordinates": [40,50],
+				"properties": {
+					"railway":"tram_stop",
+					"name":"Grundend"
+				}
+			}],
 			"caption": "Tram stop"
 		},
 		{
 			"minzoom": 11,
-			"icon": "icons/border-32.png",
+			"features": [{
+				"type": "Point",
+				"coordinates": [50,50],
+				"properties": {
+					"railway":"border"
+				}
+			}],
 			"caption": "Owner change"
 		}
 	]


### PR DESCRIPTION
This now uses exactly the same drawing for the legend as it is used in the map. While at it make the signal legends more compact by grouping similar entries in the same row. Also show German Zs3 and Zs3v light variants beneath their sign counterparts.

![canvas-legend_de](https://user-images.githubusercontent.com/10909049/38781858-d37c8316-40eb-11e8-905e-6e0481b6fb7a.png)
