### PR TITLE
Minor fixes to the legend data

### DIFF
--- a/styles/maxspeed.json
+++ b/styles/maxspeed.json
@@ -17,11 +17,6 @@
 			"caption": "speed only given for one direction"
 		},
 		{
-			"minzoom": 10,
-			"symbol": "<g fill=\"none\" stroke=\"gray\" stroke-width=\"3.5\"><path stroke-linecap=\"butt\" d=\"M5 8 l16 0\" /></g><g fill=\"none\" stroke=\"gray\" stroke-width=\"1.5\"><path stroke-linecap=\"butt\" d=\"M21 8 l16 0\" /></g>",
-			"caption": "main track, service track"
-		},
-		{
 			"minzoom": 2,
 			"maxzoom": 8,
 			"replace": [

--- a/styles/standard.json
+++ b/styles/standard.json
@@ -367,6 +367,7 @@
 		},
 		{
 			"minzoom": 8,
+			"lineheight": 20,
 			"features": [{
 				"type": "Point",
 				"coordinates": [40,50],
@@ -431,6 +432,7 @@
 		},
 		{
 			"minzoom": 11,
+			"lineheight": 20,
 			"features": [{
 				"type": "Point",
 				"coordinates": [50,50],


### PR DESCRIPTION
This fixes the "station" and "border" entry having no representation on the canvas sometimes. The station uses bold text, which is slightly higher, so it does not fit. The border icon is strange, as it was visibile on some zoom levels, but now it seems to be more stable.