### PR TITLE
English corrections and additions

### DIFF
--- a/locales/en_GB/LC_MESSAGES/messages.po
+++ b/locales/en_GB/LC_MESSAGES/messages.po
@@ -22,80 +22,80 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 
 msgid "More Info"
-msgstr "More Info"
+msgstr ""
 
 msgid "Contact"
-msgstr "Contact"
+msgstr ""
 
 msgid "Javascript is not activated"
-msgstr "Javascript is not activated"
+msgstr ""
 
 msgid ""
 "Javascript is needed to show the map and run this website. Please turn on "
 "Javascript in your browser settings."
-msgstr "Javascript is needed to show the map and run this website. Please turn on Javascript in your browser settings."
+msgstr ""
 
 msgid "Loading..."
-msgstr "Loading..."
+msgstr ""
 
 msgid "Nothing found."
-msgstr "Nothing found."
+msgstr ""
 
 msgid "Last update"
-msgstr "Last update"
+msgstr ""
 
 msgid "Empty input."
-msgstr "Empty input."
+msgstr ""
 
 msgid "Kilometer"
-msgstr "Kilometer"
+msgstr ""
 
 msgid "Track"
-msgstr "Track"
+msgstr ""
 
 msgid "Permalink"
-msgstr "Permalink"
+msgstr ""
 
 msgid "Hillshading"
-msgstr "Hillshading"
+msgstr ""
 
 msgid "Hillshading by <a href='https://www.nasa.gov/'>NASA SRTM</a>"
-msgstr "Hillshading by <a href='https://www.nasa.gov/'>NASA SRTM</a>"
+msgstr ""
 
 msgid "Rendering: OpenRailwayMap"
-msgstr "Rendering: OpenRailwayMap"
+msgstr ""
 
 msgid "Mapnik"
-msgstr "Mapnik"
+msgstr ""
 
 msgid "Mapnik Grayscale"
-msgstr "Mapnik Grayscale"
+msgstr ""
 
 msgid "Map data &copy; OpenStreetMap contributors"
-msgstr "Map data &copy; OpenStreetMap contributors"
+msgstr ""
 
 msgid "Select a map style"
-msgstr "Select a map style"
+msgstr ""
 
 msgid "Public transport"
-msgstr "Public transport"
+msgstr ""
 
 msgid "Search results"
-msgstr "Search results"
+msgstr ""
 
 msgid "Search only in the current map view"
-msgstr "Search only in the current map view"
+msgstr ""
 
 msgid "HTML-Code"
-msgstr "HTML-Code"
+msgstr ""
 
 msgid ""
 "Copy this HTML code snippet into your website to show a small map with a "
 "marker."
-msgstr "Copy this HTML code snippet into your website to show a small map with a marker."
+msgstr ""
 
 msgid "Fullscreen"
-msgstr "Fullscreen"
+msgstr ""
 
 #, php-format
 msgid "%d second"
@@ -142,397 +142,397 @@ msgid "%s ago"
 msgstr "%s ago"
 
 msgid "Infrastructure"
-msgstr "Infrastructure"
+msgstr ""
 
 msgid "Signalling"
-msgstr "Signalling"
+msgstr ""
 
 msgid "Maxspeeds"
 msgstr "Max speeds"
 
 msgid "Electrification"
-msgstr "Electrification"
+msgstr ""
 
 msgid "Halt"
-msgstr "Halt"
+msgstr ""
 
 msgid "Station"
-msgstr "Station"
+msgstr ""
 
 msgid "Junction"
-msgstr "Junction"
+msgstr ""
 
 msgid "Yard"
-msgstr "Yard"
+msgstr ""
 
 msgid "Crossover"
-msgstr "Crossover"
+msgstr ""
 
 msgid "Site"
-msgstr "Site"
+msgstr ""
 
 msgid "Service station"
-msgstr "Service station"
+msgstr ""
 
 msgid "Tram stop"
-msgstr "Tram stop"
+msgstr ""
 
 msgid "Milestone"
-msgstr "Milestone"
+msgstr ""
 
 msgid "Signal"
-msgstr "Signal"
+msgstr ""
 
 msgid "Level crossing"
-msgstr "Level crossing"
+msgstr ""
 
 msgid "Crossing"
-msgstr "Crossing"
+msgstr ""
 
 msgid "Legend"
-msgstr "Legend"
+msgstr ""
 
 msgid "Bridge"
-msgstr "Bridge"
+msgstr ""
 
 msgid "Tunnel"
-msgstr "Tunnel"
+msgstr ""
 
 msgid "Line ref"
-msgstr "Line ref"
+msgstr ""
 
 msgid "Railroad line"
-msgstr "Railroad line"
+msgstr ""
 
 msgid "Siding"
-msgstr "Siding"
+msgstr ""
 
 msgid "Yard track"
-msgstr "Yard track"
+msgstr ""
 
 msgid "Spur"
-msgstr "Spur"
+msgstr ""
 
 msgid "Crossover track"
-msgstr "Crossover track"
+msgstr ""
 
 msgid "Branch line"
-msgstr "Branch line"
+msgstr ""
 
 msgid "Main line"
-msgstr "Main line"
+msgstr ""
 
 msgid "Highspeed line"
 msgstr "High-speed line"
 
 msgid "Industrial line"
-msgstr "Industrial line"
+msgstr ""
 
 msgid "Industrial service track"
-msgstr "Industrial service track"
+msgstr ""
 
 msgid "Preserved track"
-msgstr "Preserved track"
+msgstr ""
 
 msgid "Preserved service track"
-msgstr "Preserved service track"
+msgstr ""
 
 msgid "Track under construction"
-msgstr "Track under construction"
+msgstr ""
 
 msgid "Proposed track"
-msgstr "Proposed track"
+msgstr ""
 
 msgid "Disused track"
-msgstr "Disused track"
+msgstr ""
 
 msgid "Abandoned track"
-msgstr "Abandoned track"
+msgstr ""
 
 msgid "Razed track"
-msgstr "Razed track"
+msgstr ""
 
 msgid "Tram"
-msgstr "Tram"
+msgstr ""
 
 msgid "Subway"
 msgstr "Metro"
 
 msgid "Light rail"
-msgstr "Light rail"
+msgstr ""
 
 msgid "Narrow gauge track"
-msgstr "Narrow gauge track"
+msgstr ""
 
 msgid "Switch (remote-controlled)"
-msgstr "Switch (remote-controlled)"
+msgstr ""
 
 msgid "Switch (local operated)"
-msgstr "Switch (local operated)"
+msgstr ""
 
 msgid "Resetting switch"
-msgstr "Resetting switch"
+msgstr ""
 
 msgid "Signal box"
-msgstr "Signal box"
+msgstr ""
 
 msgid "Owner change"
-msgstr "Owner change"
+msgstr ""
 
 msgid "Railway crossing"
-msgstr "Railway crossing"
+msgstr ""
 
 msgid "Buffer stop"
-msgstr "Buffer stop"
+msgstr ""
 
 msgid "Isolated track section"
-msgstr "Isolated track section"
+msgstr ""
 
 msgid "Platform"
-msgstr "Platform"
+msgstr ""
 
 msgid "Vending machine"
-msgstr "Vending machine"
+msgstr ""
 
 msgid "Ticket shop"
-msgstr "Ticket shop"
+msgstr ""
 
 msgid "Subway entrance"
 msgstr "Metro entrance"
 
 msgid "Phone"
-msgstr "Phone"
+msgstr ""
 
 msgid "Water tower"
-msgstr "Water tower"
+msgstr ""
 
 msgid "Fuel"
-msgstr "Fuel"
+msgstr ""
 
 msgid "Water crane"
-msgstr "Water crane"
+msgstr ""
 
 msgid "Coaling facility"
-msgstr "Coaling facility"
+msgstr ""
 
 msgid "Wash"
-msgstr "Wash"
+msgstr ""
 
 msgid "Pit"
-msgstr "Pit"
+msgstr ""
 
 msgid "Loading gauge"
-msgstr "Loading gauge"
+msgstr ""
 
 msgid "Hump yard"
-msgstr "Hump yard"
+msgstr ""
 
 msgid "Rail brake"
-msgstr "Rail brake"
+msgstr ""
 
 msgid "Engine shed"
-msgstr "Engine shed"
+msgstr ""
 
 msgid "Workshop"
-msgstr "Workshop"
+msgstr ""
 
 msgid "Radio tower"
-msgstr "Radio tower"
+msgstr ""
 
 msgid "Turntable"
-msgstr "Turntable"
+msgstr ""
 
 msgid "Traverser"
-msgstr "Traverser"
+msgstr ""
 
 msgid "Loading ramp"
-msgstr "Loading ramp"
+msgstr ""
 
 msgid "Crane"
-msgstr "Crane"
+msgstr ""
 
 msgid "Track scale"
-msgstr "Track scale"
+msgstr ""
 
 msgid "Carrier truck pit"
-msgstr "Carrier truck pit"
+msgstr ""
 
 msgid "Gauge conversion"
-msgstr "Gauge conversion"
+msgstr ""
 
 msgid "Gate"
-msgstr "Gate"
+msgstr ""
 
 msgid "Museum"
-msgstr "Museum"
+msgstr ""
 
 msgid "Container terminal"
-msgstr "Container terminal"
+msgstr ""
 
 msgid "Station building"
-msgstr "Station building"
+msgstr ""
 
 msgid "Factory connected to railroad line"
-msgstr "Factory connected to railroad line"
+msgstr ""
 
 msgid "Rack"
-msgstr "Rack"
+msgstr ""
 
 msgid "Embankment"
-msgstr "Embankment"
+msgstr ""
 
 msgid "Cutting"
-msgstr "Cutting"
+msgstr ""
 
 msgid "Miniature railway"
-msgstr "Miniature railway"
+msgstr ""
 
 msgid "Funicular"
-msgstr "Funicular"
+msgstr ""
 
 msgid "Military line"
-msgstr "Military line"
+msgstr ""
 
 msgid "Military service track"
-msgstr "Military service track"
+msgstr ""
 
 msgid "Ferry terminal"
-msgstr "Ferry terminal"
+msgstr ""
 
 msgid "Ferry"
-msgstr "Ferry"
+msgstr ""
 
 msgid "Test line"
-msgstr "Test line"
+msgstr ""
 
 msgid "Test service track"
-msgstr "Test service track"
+msgstr ""
 
 msgid "Car shuttle"
-msgstr "Car shuttle"
+msgstr ""
 
 msgid "Rolling highway"
-msgstr "Rolling highway"
+msgstr ""
 
 msgid "Nothing to see in this zoom level. Please zoom in."
-msgstr "Nothing to see in this zoom level. Please zoom in."
+msgstr ""
 
 msgid "Legend not available for this style."
-msgstr "Legend not available for this style."
+msgstr ""
 
 msgid "Language"
-msgstr "Language"
+msgstr ""
 
 msgid "Desktop version"
-msgstr "Desktop version"
+msgstr ""
 
 msgid "Style"
-msgstr "Style"
+msgstr ""
 
 msgid "Search"
-msgstr "Search"
+msgstr ""
 
 msgid "Blog"
-msgstr "Blog"
+msgstr ""
 
 msgid "No information"
-msgstr "No information"
+msgstr ""
 
 msgid "speed only given for one direction"
-msgstr "speed only given for one direction"
+msgstr ""
 
 msgid "main track, service track"
-msgstr "main track, service track"
+msgstr ""
 
 msgid "Quick search shortcut"
-msgstr "Quick search shortcut"
+msgstr ""
 
 msgid "Placeholder"
-msgstr "Placeholder"
+msgstr ""
 
 msgid "Donate"
-msgstr "Donate"
+msgstr ""
 
 msgid "Tools"
-msgstr "Tools"
+msgstr ""
 
 msgid "Wiki"
-msgstr "Wiki"
+msgstr ""
 
 msgid "Search milestone"
-msgstr "Search milestone"
+msgstr ""
 
 msgid "Station code"
-msgstr "Station code"
+msgstr ""
 
 msgid "Search station"
-msgstr "Search station"
+msgstr ""
 
 msgid "UIC reference"
-msgstr "UIC reference"
+msgstr ""
 
 msgid "About this project"
-msgstr "About this project"
+msgstr ""
 
 msgid "Close"
-msgstr "Close"
+msgstr ""
 
 msgid "Name"
-msgstr "Name"
+msgstr ""
 
 msgid "Line operator"
-msgstr "Line operator"
+msgstr ""
 
 msgid "Operator"
-msgstr "Operator"
+msgstr ""
 
 msgid "More results"
-msgstr "More results"
+msgstr ""
 
 msgid "Spur junction"
-msgstr "Spur junction"
+msgstr ""
 
 msgid "No background map"
-msgstr "No background map"
+msgstr ""
 
 msgid "Deelectrified"
 msgstr "De-electrified"
 
 msgid "No information about train protection"
-msgstr "No information about train protection"
+msgstr ""
 
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "Track usage"
-msgstr "Track usage"
+msgstr ""
 
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
-msgstr "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
+msgstr ""
 
 msgid "1.5 – 3kV ="
-msgstr "1.5 – 3kV ="
+msgstr ""
 
 msgid "ETCS under construction"
-msgstr "ETCS under construction"
+msgstr ""
 
 msgid "3kV ="
-msgstr "3kV ="
+msgstr ""
 
 msgid "Germany"
-msgstr "Germany"
+msgstr ""
 
 msgid "Not electrified"
-msgstr "Not electrified"
+msgstr ""
 
 msgid "shunting signal type Ro"
-msgstr "Shunting signal type Ro"
+msgstr ""
 
 msgid "Track type"
-msgstr "Track type"
+msgstr ""
 
 msgid "El 5 \"Bügel an\"-Signal"
 msgstr ""
@@ -541,7 +541,7 @@ msgid "Linienzugbeeinflussung"
 msgstr ""
 
 msgid "25kV 50Hz ~"
-msgstr "25kV 50Hz ~"
+msgstr ""
 
 msgid "So 106 Kreuztafel"
 msgstr ""
@@ -550,28 +550,28 @@ msgid "Ra 11 Wartezeichen mit Sh 1"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
-msgstr "Junction, Crossover, Service Station, Site"
+msgstr ""
 
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "At least 25kV ~"
-msgstr "At least 25kV ~"
+msgstr ""
 
 msgid "minor signal type Lo"
 msgstr "Minor signal type Lo"
 
 msgid "Finland"
-msgstr "Finland"
+msgstr ""
 
 msgid "15 – 25kV ~"
-msgstr "15 – 25kV ~"
+msgstr ""
 
 msgid "ETCS"
-msgstr "ETCS"
+msgstr ""
 
 msgid "Electrification under construction"
-msgstr "Electrification under construction"
+msgstr ""
 
 msgid "no train protection"
 msgstr "No train protection"
@@ -586,7 +586,7 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr "15kV 16⅔Hz ~"
+msgstr ""
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
@@ -598,40 +598,40 @@ msgid "Ne 5 Haltetafel"
 msgstr ""
 
 msgid "Voltage"
-msgstr "Voltage"
+msgstr ""
 
 msgid "More than 3kV ="
-msgstr "More than 3kV ="
+msgstr ""
 
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
-msgstr "3rd rail"
+msgstr ""
 
 msgid "750 – 1000V ="
-msgstr "750 – 1000V ="
+msgstr ""
 
 msgid "Less than 15kV ~"
-msgstr "Less than 15kV ~"
+msgstr ""
 
 msgid "1kV ="
-msgstr "1kV ="
+msgstr ""
 
 msgid "crossing signal type To"
 msgstr "Crossing signal type To"
 
 msgid "1 – 1.5kV ="
-msgstr "1 – 1.5kV ="
+msgstr ""
 
 msgid "block signal type So"
 msgstr "Block signal type So"
 
 msgid "%SPDMIN%-%SPDMAX% km/h"
-msgstr "%SPDMIN%-%SPDMAX% km/h"
+msgstr ""
 
 msgid "1.5kV ="
-msgstr "1.5kV ="
+msgstr ""
 
 msgid "El 2 Einschaltsignal"
 msgstr ""
@@ -652,13 +652,13 @@ msgid "El 6 Halt für Fahrzeuge mit gehobenem Stromabnehmer"
 msgstr ""
 
 msgid "Less than 750V ="
-msgstr "Less than 750V ="
+msgstr ""
 
 msgid "Punktförmige Zugbeeinflussung"
-msgstr "PZB"
+msgstr ""
 
 msgid "Operating Sites"
-msgstr "Operating Sites"
+msgstr ""
 
 msgid "train protection"
 msgstr "Train protection"
@@ -670,22 +670,22 @@ msgid "El 4 \"Bügel ab\"-Signal"
 msgstr ""
 
 msgid "750V ="
-msgstr "750V ="
+msgstr ""
 
 msgid "25kV 60Hz ~"
-msgstr "25kV 60Hz ~"
+msgstr ""
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
 msgstr ""
 
 msgid "Electrification proposed"
-msgstr "Electrification proposed"
+msgstr ""
 
 msgid "El 1v Ausschaltsignal erwarten"
 msgstr ""
 
 msgid "15kV 16.7Hz ~"
-msgstr "15kV 16.7Hz ~"
+msgstr ""
 
 msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
 msgstr ""

--- a/locales/en_GB/LC_MESSAGES/messages.po
+++ b/locales/en_GB/LC_MESSAGES/messages.po
@@ -11,7 +11,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2013-03-08 12:29+0100\n"
 "PO-Revision-Date: 2017-09-19 19:36+0000\n"
-"Last-Translator: Alexander Matheisen <alex@matheisen.org>\n"
+"Last-Translator: Daniel Brvnistan <daniel.brvnistan@gmail.com>\n"
 "Language-Team: English (https://www.transifex.com/rurseekatze/openrailwaymap/language/en/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -148,10 +148,10 @@ msgid "Signalling"
 msgstr "Signalling"
 
 msgid "Maxspeeds"
-msgstr "Maxspeeds"
+msgstr "Max speeds"
 
 msgid "Electrification"
-msgstr ""
+msgstr "Electrification"
 
 msgid "Halt"
 msgstr "Halt"
@@ -223,7 +223,7 @@ msgid "Main line"
 msgstr "Main line"
 
 msgid "Highspeed line"
-msgstr "Highspeed line"
+msgstr "High-speed line"
 
 msgid "Industrial line"
 msgstr "Industrial line"
@@ -256,7 +256,7 @@ msgid "Tram"
 msgstr "Tram"
 
 msgid "Subway"
-msgstr "Subway"
+msgstr "Metro"
 
 msgid "Light rail"
 msgstr "Light rail"
@@ -298,7 +298,7 @@ msgid "Ticket shop"
 msgstr "Ticket shop"
 
 msgid "Subway entrance"
-msgstr "Subway entrance"
+msgstr "Metro entrance"
 
 msgid "Phone"
 msgstr "Phone"
@@ -496,43 +496,43 @@ msgid "No background map"
 msgstr "No background map"
 
 msgid "Deelectrified"
-msgstr ""
+msgstr "De-electrified"
 
 msgid "No information about train protection"
-msgstr ""
+msgstr "No information about train protection"
 
 msgid "Hp-Lichthauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "Track usage"
-msgstr ""
+msgstr "Track usage"
 
 msgid "Lf 7 Geschwindigkeitssignal"
 msgstr ""
 
 msgid "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
-msgstr ""
+msgstr "%SPDMIN%-%SPDMAX% km/h (disused/under construction)"
 
 msgid "1.5 – 3kV ="
-msgstr ""
+msgstr "1.5 – 3kV ="
 
 msgid "ETCS under construction"
-msgstr ""
+msgstr "ETCS under construction"
 
 msgid "3kV ="
-msgstr ""
+msgstr "3kV ="
 
 msgid "Germany"
-msgstr ""
+msgstr "Germany"
 
 msgid "Not electrified"
-msgstr ""
+msgstr "Not electrified"
 
 msgid "shunting signal type Ro"
-msgstr ""
+msgstr "Shunting signal type Ro"
 
 msgid "Track type"
-msgstr ""
+msgstr "Track type"
 
 msgid "El 5 \"Bügel an\"-Signal"
 msgstr ""
@@ -541,7 +541,7 @@ msgid "Linienzugbeeinflussung"
 msgstr ""
 
 msgid "25kV 50Hz ~"
-msgstr ""
+msgstr "25kV 50Hz ~"
 
 msgid "So 106 Kreuztafel"
 msgstr ""
@@ -550,31 +550,31 @@ msgid "Ra 11 Wartezeichen mit Sh 1"
 msgstr ""
 
 msgid "Junction, Crossover, Service Station, Site"
-msgstr ""
+msgstr "Junction, Crossover, Service Station, Site"
 
 msgid "Hp-Formhauptsignal ohne Angabe der Signalzustände"
 msgstr ""
 
 msgid "At least 25kV ~"
-msgstr ""
+msgstr "At least 25kV ~"
 
 msgid "minor signal type Lo"
-msgstr ""
+msgstr "Minor signal type Lo"
 
 msgid "Finland"
-msgstr ""
+msgstr "Finland"
 
 msgid "15 – 25kV ~"
-msgstr ""
+msgstr "15 – 25kV ~"
 
 msgid "ETCS"
-msgstr ""
+msgstr "ETCS"
 
 msgid "Electrification under construction"
-msgstr ""
+msgstr "Electrification under construction"
 
 msgid "no train protection"
-msgstr ""
+msgstr "No train protection"
 
 msgid "Blockkennzeichen"
 msgstr ""
@@ -586,52 +586,52 @@ msgid "Ne 1 Trapeztafel"
 msgstr ""
 
 msgid "15kV 16⅔Hz ~"
-msgstr ""
+msgstr "15kV 16⅔Hz ~"
 
 msgid "Ra 11 Wartezeichen ohne Sh 1 / Wartesignal ohne 'Verschubverbot aufgehoben'"
 msgstr ""
 
 msgid "signals"
-msgstr ""
+msgstr "Signals"
 
 msgid "Ne 5 Haltetafel"
 msgstr ""
 
 msgid "Voltage"
-msgstr ""
+msgstr "Voltage"
 
 msgid "More than 3kV ="
-msgstr ""
+msgstr "More than 3kV ="
 
 msgid "Lf 6 Geschwindigkeits­ankündesignal"
 msgstr ""
 
 msgid "3rd rail"
-msgstr ""
+msgstr "3rd rail"
 
 msgid "750 – 1000V ="
-msgstr ""
+msgstr "750 – 1000V ="
 
 msgid "Less than 15kV ~"
-msgstr ""
+msgstr "Less than 15kV ~"
 
 msgid "1kV ="
-msgstr ""
+msgstr "1kV ="
 
 msgid "crossing signal type To"
-msgstr ""
+msgstr "Crossing signal type To"
 
 msgid "1 – 1.5kV ="
-msgstr ""
+msgstr "1 – 1.5kV ="
 
 msgid "block signal type So"
-msgstr ""
+msgstr "Block signal type So"
 
 msgid "%SPDMIN%-%SPDMAX% km/h"
-msgstr ""
+msgstr "%SPDMIN%-%SPDMAX% km/h"
 
 msgid "1.5kV ="
-msgstr ""
+msgstr "1.5kV ="
 
 msgid "El 2 Einschaltsignal"
 msgstr ""
@@ -652,46 +652,46 @@ msgid "El 6 Halt für Fahrzeuge mit gehobenem Stromabnehmer"
 msgstr ""
 
 msgid "Less than 750V ="
-msgstr ""
+msgstr "Less than 750V ="
 
 msgid "Punktförmige Zugbeeinflussung"
-msgstr ""
+msgstr "PZB"
 
 msgid "Operating Sites"
-msgstr ""
+msgstr "Operating Sites"
 
 msgid "train protection"
-msgstr ""
+msgstr "Train protection"
 
 msgid "contact line"
-msgstr ""
+msgstr "Overhead line"
 
 msgid "El 4 \"Bügel ab\"-Signal"
 msgstr ""
 
 msgid "750V ="
-msgstr ""
+msgstr "750V ="
 
 msgid "25kV 60Hz ~"
-msgstr ""
+msgstr "25kV 60Hz ~"
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
 msgstr ""
 
 msgid "Electrification proposed"
-msgstr ""
+msgstr "Electrification proposed"
 
 msgid "El 1v Ausschaltsignal erwarten"
 msgstr ""
 
 msgid "15kV 16.7Hz ~"
-msgstr ""
+msgstr "15kV 16.7Hz ~"
 
 msgid "Sh-Lichtsperrsignal (normal, Zwergsignal)"
 msgstr ""
 
 msgid "distant signal with Eo 2 (new type)"
-msgstr ""
+msgstr "Distant signal with Eo 2 (new type)"
 
 msgid "Ks-Hauptsignal"
 msgstr ""
@@ -727,22 +727,22 @@ msgid "Vr-Formvorsignal (ohne Vr 2, mit Vr 2)"
 msgstr ""
 
 msgid "main signal without aspects given (new type, old type)"
-msgstr ""
+msgstr "Main signal without aspects given (new type, old type)"
 
 msgid "Hp-Lichthauptsignal (ohne Hp 2, mit Hp 2)"
 msgstr ""
 
 msgid "main signal with Po 1 (new type, old type)"
-msgstr ""
+msgstr "Main signal with Po 1 (new type, old type)"
 
 msgid "main signal with Po 2 (new type, old type)"
-msgstr ""
+msgstr "Main signal with Po 2 (new type, old type)"
 
 msgid "El 3 \"Bügel ab\"-Ankündigungssignal"
 msgstr ""
 
 msgid "distant signal with Eo 1 (new type, old type)"
-msgstr ""
+msgstr "Distant signal with Eo 1 (new type, old type)"
 
 msgid "Vr-Lichtvorsignal ohne Vr 2 (normal, Wiederholer/verkürzter Bremswegabstand)"
 msgstr ""
@@ -763,7 +763,7 @@ msgid "Vr-Lichtvorsignal ohne Angabe der Signalzustände (normal, Wiederholer/ve
 msgstr ""
 
 msgid "distant signal without aspects given (new type, old type)"
-msgstr ""
+msgstr "Distant signal without aspects given (new type, old type)"
 
 msgid "Zs 3v Geschwindigkeits­voranzeiger (Tafel, Lichtsignal)"
 msgstr ""
@@ -772,4 +772,4 @@ msgid "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgstr ""
 
 msgid "Imprint &amp; Privacy Policy"
-msgstr "Imprint &amp; Privacy Policy"
+msgstr "Copyright &amp; Privacy Policy"


### PR DESCRIPTION
Added missing "translations" to English.
I could not do de>en translations.
Is the msgid (German in some cases) value used in case msgstr is empty?

Corrected some terms to match the correct spelling or most widely used term from several choices e g. these two that you may disagree with:
highspeed > high-speed (https://en.wikipedia.org/wiki/High-speed_rail)
subway > metro (https://en.wikipedia.org/wiki/Rapid_transit#Terminology)