### PR TITLE
Add special page about EU upload filters

### DIFF
--- a/uf.html
+++ b/uf.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+		<meta http-equiv="content-language" content="de,en" />
+
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+		<title>Stop Article 13 now! – OpenRailwayMap</title>
+		<meta name="title" content="Stop Article 13 now! – OpenRailwayMap" />
+		<meta name="description" content="OpenRailwayMap, an OpenStreetMap-based project for creating a map of the world&#39;s railway infrastructure, protests against upload filters." />
+		<meta name="keywords" content="openstreetmap, openrailwaymap, alexander matheisen, rurseekatze, openlayers, osm, matheisen, orm, eisenbahnkarte, bahnkarte, railmap, railway, railways, eisenbahn, streckenkarte" />
+		<meta name="robots" content="index,follow" />
+
+		<link rel="alternate" type="application/rss+xml" title="OpenRailwayMap Deutsch" href="https://blog.openrailwaymap.org/de.rss" hreflang="de" />
+		<link rel="alternate" type="application/rss+xml" title="OpenRailwayMap English" href="https://blog.openrailwaymap.org/en.rss" hreflang="en" />
+
+		<link rel="search" type="application/opensearchdescription+xml" href="opensearch.xml" title="OpenRailwayMap" />
+
+		<link rel="shortcut icon" href="img/openrailwaymap-16.png" type="image/png" />
+		<link rel="icon" href="img/openrailwaymap-16.png" type="image/png" />
+
+		<meta http-equiv="content-script-type" content="text/javascript" />
+		<meta http-equiv="content-style-type" content="text/css" />
+
+		<link rel="stylesheet" type="text/css" href="css/map.css" />
+
+		<meta name="mobile-web-app-capable" content="yes">
+		<meta name="apple-mobile-web-app-capable" content="yes">
+		<meta name="apple-mobile-web-app-title" content="OpenRailwayMap">
+		<link rel="manifest" href="webapp-manifest.json">
+		<meta name="theme-color" content="#4e9a06">
+
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:site" content="@openrailwaymap" />
+		<meta name="twitter:title" content="OpenRailwayMap" />
+		<meta name="twitter:description" content="OpenRailwayMap - An OpenStreetMap-based project for creating a map of the world&amp;#39;s railway infrastructure." />
+		<meta name="twitter:url" content="https://www.openrailwaymap.org/">
+		<meta name="twitter:image" content="https://www.openrailwaymap.org/img/openrailwaymap-310.png" />
+		<style>
+			html, body, body * {
+				background-color: black;
+				color: white;
+			}
+		
+			.footnote, .imprint-link {
+				font-size: 80%;
+			}
+		
+			@media print {
+				html, body {
+					background-color: white;
+					color: black;
+				}
+			}
+		
+			div.side-by-side-container {
+				margin-left: auto;
+				margin-right: auto;
+				max-width: 1700px;
+			}
+		
+			div.side-by-side {
+				display: inline-block;
+				width: calc(50% - 65px);
+				padding-left: 20px;
+				padding-right: 20px;
+				vertical-align: top;
+			}
+		
+			@media screen and (max-width: 600px) {
+				div.side-by-side {
+					display: block; 
+					width: initial; 
+					padding-bottom: 30px;
+				}
+			}
+		</style>
+	</head>
+	<body>
+		<div class="side-by-side-container">
+			<div class="side-by-side">
+				<h1>Die EU-Urheber&shy;rechts&shy;richtlinie bedroht das Internet, OpenStreetMap und die OpenRailwayMap</h1>
+				<p>
+				Liebe Benutzerin, lieber Benutzer,
+				</p>
+				<p>
+				normalerweise haben Sie hier die Möglichkeit, eine auf den Daten des OpenStreetMap-Projekts
+				basierende Eisenbahnkarte zu betrachten. Der Betreiber der OpenRailwayMap sieht sich jedoch
+				genötigt, Ihre Aufmerksamkeit heute auf etwas anderes zu lenken. Deshalb ist heute die
+				gewöhnliche Nutzung der OpenRailwayMap nur sehr eingeschränkt möglich.*
+				</p>
+	
+				<p>
+				Am Dienstag, den 26. März 2019, stimmt das Europäische Parlement über die EU-Richtlinie
+				<em>Urheberrecht im digitalen Binnenmarkt</em> ab. Leider bedroht die Richtlinie in Ihrer
+				aktuellen Form das Internet und insbesondere freie Inhalte, wie wir sie kennen. Das
+				OpenStreetMap-Projekt, dessen Daten Sie hier normalerweise sehen können, ist hiervon
+				auch betroffen.
+				</p>
+	
+				<p>
+				Artikel 13 der Richtlinie führt für Inhalteplattformen im Internet die Pflicht ein,
+				das Hochladen von Urheberrechtsverletzungen durch ihre Nutzer aktiv zu verhindern und
+				hebt das Haftungsprivileg der Plattformbetreiber auf. Bislang hafteten diese erst, wenn
+				Sie auf die Meldung einer Urheberrechtsverletzung nicht unverzüglich reagiert hatten.
+				Leider ist der Begriff Inhalteplattformen nicht genau definiert, weshalb davon ausgegangen
+				werden muss, dass er recht weit ausgelegt werden kann. Er würde voraussichtlich nicht nur
+				soziale Netzwerke wie Facebook und Videoplattformen wie Youtube erfassen. Es kann davon
+				ausgegangen werden, dass sämtliche Internetseiten, auf denen Internetnutzer Inhalte
+				beitragen können, z.B. ein Blog mit Kommentarfunktion oder ein Online-Forum, betroffen
+				wären. Viele Betreiber sind finanziell nicht in der Lage, diese Anforderung zu stemmen!
+				</p>
+	
+				<p>
+				Auch OpenStreetMap wäre betroffen. Das OpenStreetMap-Projekt wäre gezwungen, sämtliche
+				Beiträge zu prüfen, was enorme finanzielle und personelle Ressourcen des von
+				Ehrenamtlichen getragenen Projekts binden würde – von der stellenweise technischen
+				Unmöglichkeit der Umsetzung ganz zu schweigen. Auf
+				<a href="https://www.openstreetmap.de/uf/index.html">openstreetmap.de</a> werden die
+				Gefahren für das OpenStreetMap-Projekt genauer erklärt.
+				</p>
+	
+				<p style="font-weight: bold; font-size: 130%;">
+				Am 23. März finden in über 30 Städten in Europa Demonstrationen gegen die
+				EU-Urheberrechtsrichtlinie statt. Bitte nehmen Sie daran teil.
+				</p>
+
+				<p>
+				Die genauen Orte finden Sie unter <a href="https://savetheinternet.info/demos">https://savetheinternet.info/demos</a>.
+				</p>
+	
+				<p class="footnote">
+				* Der Zugriff auf Kartenkacheln und die API ist weiterhin möglich.
+				</p>
+
+				<p class="imprint-link"><a href="/imprint-de.html">Impressum und Datenschutz</a></p>
+			</div>
+			<div class="side-by-side">
+				<h1>Die EU Copyright Directive Will Harm the Internet, OpenStreetMap and OpenRailwayMap</h1>
+				<p>
+				Dear user,
+				</p>
+				<p>
+				usually, you can view a railway map based on the data of the OpenStreetMap project at this website.
+				However, the operator of the OpenRailwayMap project feels the urgent need to direct your attention
+				on something different today. Therefore, the usage of this website is limited today*.
+				</p>
+	
+				<p>
+				On Tuesday, 26 March 2019 the European Parliament will vote on the EU Directive
+				<em>Copyright in the Single Digital Market</em>. Unfortunately, the current draft of the directive
+				threatens the internet and especially free contents on the internet as we are used to have.
+				The OpenStreetMap project whose data you could usually view on this website, will be affected, too.
+				</p>
+	
+				<p>
+				Article 13 of the directive introduces the requirement for content platforms on the internet
+				to prevent uploads of material violating copyright and removes the excemption of those platforms
+				from the liability. Up to now, they were liable, if they do not react on reports of copyright
+				violations in a timely manner. Unfortunately, the term content platform is not defined precisely.
+				That's why one has to assume that it can be interpreted very liberal. It would not affect
+				social networks like Facebook and video platforms like Youtube only. One can assume that all
+				websites where internet users can contribute contents, e.g. a blog with comments or a forum,
+				would be affected. Many operators are unable to pay the changes to their websites required by
+				the directive!
+				</p>
+	
+				<p>
+				OpenStreetMap would be affected as well. The OpenStreetMap project would be forced to
+				review all contributions leading to requiring large financial resources and a lot of workpower
+				of this project run by volunteers – leaving the technical impossiblity to implement the changes
+				aside.  <a href="https://www.openstreetmap.de/uf/en.html">openstreetmap.de</a> explains the threats
+				to the OpenStreetMap project in detail.
+				</p>
+	
+				<p style="font-weight: bold; font-size: 130%;">
+				There will be demonstrations in more then 30 cities in Europe on 23 March against the EU Copyright Directive.
+				Please join one of these demonstrations.
+				</p>
+
+				<p>
+				You can find the locations at <a href="https://savetheinternet.info/demos">https://savetheinternet.info/demos</a>.
+				</p>
+	
+				<p class="footnote">
+				* Access to map tiles and API is not affected.
+				</p>
+
+				<p class="imprint-link"><a href="/imprint-en.html">legal notice and privacy</a></p>
+			</div>
+                </div>
+	</body>
+</html>


### PR DESCRIPTION
You can redirect all requests for the index.php page and the mobile.php
page to this page by enabling mod_alias and adding the following lines
to the Apache configuration:

    RedirectMatch temp "^/index.php$" "/uf.html"
    RedirectMatch temp "^/$" "/uf.html"

This change should be live on 21 March (and a few hours before and after it) only.

Geofabrik will have a very similar page replacing all calls to any .html pages of download.geofabrik.de on 21 March.