### PR TITLE
ETCS under construction - dashing and color fix

### DIFF
--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -84,8 +84,7 @@ way["construction:railway:etcs"]["construction:railway:etcs"!=no]["construction:
 way.ctracks
 {
 	z-index: 9;
-	color: blue;
-	dashes: 9,9;
+	color: lightskyblue;
 }
 way["railway:etcs"]["railway:etcs"!=no]["railway:etcs"!=0].tracks
 {


### PR DESCRIPTION
Fixes #631 

Dashing is wrongly rendered on many zoom levels. Removing it and changing color to light blue looks like a better idea.