### PR TITLE
standard style: render usage=military even if service is given

### DIFF
--- a/styles/common.mapcss
+++ b/styles/common.mapcss
@@ -55,7 +55,7 @@ way|z9-[railway=proposed]["proposed:usage"="branch"][!"proposed:service"][!"prop
 way|z9-[railway=proposed]["usage"="branch"][!"service"][!"proposed"]["proposed:railway"!="light_rail"]["proposed:railway"!="subway"]["proposed:railway"!="tram"]["proposed:railway"!="platform"],
 way|z9-[railway=proposed]["proposed:usage"="main"][!"proposed:service"][!"proposed:railway"]["proposed"!="light_rail"]["proposed"!="subway"]["proposed"!="tram"]["proposed"!="platform"],
 way|z9-[railway=proposed]["usage"="main"][!"service"][!"proposed:railway"]["proposed"!="light_rail"]["proposed"!="subway"]["proposed"!="tram"]["proposed"!="platform"],
-way|z10-[railway=proposed]["proposed:railway"!="tram"],
+way|z10-[railway=proposed]["proposed:railway"]["proposed:railway"!="tram"],
 way|z10-[railway=proposed][!"proposed:railway"]["proposed"!="tram"],
 way|z11-[railway=proposed]["proposed:railway"="tram"],
 way|z11-[railway=proposed][!"proposed:railway"]["proposed"="tram"]
@@ -67,7 +67,7 @@ way|z9-[railway=construction]["construction:usage"="branch"][!"construction:serv
 way|z9-[railway=construction]["usage"="branch"][!"service"][!"construction"]["construction:railway"!="light_rail"]["construction:railway"!="subway"]["construction:railway"!="tram"]["construction:railway"!="platform"],
 way|z9-[railway=construction]["construction:usage"="main"][!"construction:service"][!"construction:railway"]["construction"!="light_rail"]["construction"!="subway"]["construction"!="tram"]["construction"!="platform"],
 way|z9-[railway=construction]["usage"="main"][!"service"][!"construction:railway"]["construction"!="light_rail"]["construction"!="subway"]["construction"!="tram"]["construction"!="platform"],
-way|z10-[railway=construction]["construction:railway"!="tram"],
+way|z10-[railway=construction]["construction:railway"]["construction:railway"!="tram"],
 way|z10-[railway=construction][!"construction:railway"]["construction"!="tram"],
 way|z11-[railway=construction]["construction:railway"="tram"],
 way|z11-[railway=construction][!"construction:railway"]["construction"="tram"]

--- a/styles/standard.mapcss
+++ b/styles/standard.mapcss
@@ -183,7 +183,7 @@ way|z17-["railway:track_ref"].tracks
 /***************************************************************************************/
 way[!usage][!service].tracks,
 way[usage=tourism][!service].tracks,
-way[usage=military][!service].tracks,
+way[usage=military].tracks,
 way[usage=test][!service].tracks,
 way[!usage][service=siding].tracks,
 way[!usage][service=yard].tracks,
@@ -286,7 +286,7 @@ way[railway=proposed]["proposed"=tram].tracks
 /***************************************************************************************/
 way|z10-[railway=rail][!usage][!service],
 way|z10-[railway=rail][usage=tourism][!service],
-way|z10-[railway=rail][usage=military][!service],
+way|z10-[railway=rail][usage=military],
 way|z10-[railway=rail][usage=test][!service]
 {
 	z-index: 400;
@@ -490,7 +490,7 @@ way|z10-[railway=light_rail]
 /*******************************************************************************************/
 way|z9-[railway=narrow_gauge][!usage][!service],
 way|z9-[railway=narrow_gauge][usage=tourism][!service],
-way|z9-[railway=narrow_gauge][usage=military][!service],
+way|z9-[railway=narrow_gauge][usage=military],
 way|z9-[railway=narrow_gauge][usage=test][!service]
 {
 	z-index: 1200;


### PR DESCRIPTION
This is one of the 2 exceptions where both tags are allowed at the same time.

Fixes #664.