### PR TITLE
Drop logging of API into api.log

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -14,17 +14,6 @@ log4js.configure(
 	[
 		{
 			"type": "logLevelFilter",
-			"level": "ERROR",
-			"appender":
-			{
-				"type": "file",
-				"filename": 'api.log', 
-				'maxLogSize': 20480,
-				'backups': 0
-			}
-		},
-		{
-			"type": "logLevelFilter",
 			"level": "INFO",
 			"appender":
 			{


### PR DESCRIPTION
We do not need to log errors to a file in the current directory if we log to stdout (forwarded to Rsyslogd in production) with log level INFO. The logging to a file fails if the user running the API daemon has no write permissions in the API source code repositoy (which I consider good practice in production).

The logging to a file was introduced in commit 89c34760e4b2c440c40e145f39a52a70e7e99fa0