### PR TITLE
dismanteld = razed

### DIFF
--- a/styles/common.mapcss
+++ b/styles/common.mapcss
@@ -47,6 +47,12 @@ way|z9-[railway=razed]["razed:usage"="main"][!"razed:service"]["razed:railway"!=
 way|z9-[railway=razed]["usage"="main"][!"service"]["razed:railway"!="light_rail"]["razed:railway"!="subway"]["razed:railway"!="tram"],
 way|z10-[railway=razed]["razed:railway"!="tram"],
 way|z11-[railway=razed]["razed:railway"="tram"]
+way|z9-[railway=dismantled]["dismantled:usage"="branch"][!"dismantled:service"]["dismantled:railway"!="light_rail"]["dismantled:railway"!="subway"]["dismantled:railway"!="tram"],
+way|z9-[railway=dismantled]["usage"="branch"][!"service"]["dismantled:railway"!="light_rail"]["dismantled:railway"!="subway"]["dismantled:railway"!="tram"],
+way|z9-[railway=dismantled]["dismantled:usage"="main"][!"dismantled:service"]["dismantled:railway"!="light_rail"]["dismantled:railway"!="subway"]["dismantled:railway"!="tram"],
+way|z9-[railway=dismantled]["usage"="main"][!"service"]["dismantled:railway"!="light_rail"]["dismantled:railway"!="subway"]["dismantled:railway"!="tram"],
+way|z10-[railway=dismantled]["dismantled:railway"!="tram"],
+way|z11-[railway=dismantled]["dismantled:railway"="tram"]
 {
 	set .tracks_razed;
 }

--- a/styles/standard.mapcss
+++ b/styles/standard.mapcss
@@ -80,6 +80,7 @@ way|z12-[!"railway:track_ref"].bridge::bridges
 way|z9-[railway=disused].tracks,
 way|z9-[railway=abandoned].tracks,
 way|z9-[railway=razed].tracks
+way|z9-[railway=dismantled].tracks
 {
 	z-index: 10;
 	casing-color: black;
@@ -154,6 +155,11 @@ way|z11-[railway=razed][!bridge][!tunnel]["razed:name"],
 way|z11-[railway=razed][!bridge][!tunnel]["razed:ref"]
 {
 	text: eval(join(" ", tag("razed:ref"), tag("razed:name")));
+}
+way|z11-[railway=dismantled][!bridge][!tunnel]["dismantled:name"],
+way|z11-[railway=dismantled][!bridge][!tunnel]["dismantled:ref"]
+{
+	text: eval(join(" ", tag("dismantled:ref"), tag("dismantled:name")));
 }
 
 /*****************************************/
@@ -464,6 +470,7 @@ way|z9-[railway=abandoned]
 /* razed railways */
 /******************/
 way|z9-[railway=razed]
+way|z9-[railway=dismantled]
 {
 	z-index: 200;
 	dashes: 3,7;

--- a/validator/openrailwaymap.validator.mapcss
+++ b/validator/openrailwaymap.validator.mapcss
@@ -689,6 +689,7 @@ area[building=railway_station]
 way|z9-[railway=disused][!"disused:railway"],
 way|z9-[railway=abandoned][!"abandoned:railway"],
 way|z9-[railway=razed][!"razed:railway"],
+way|z9-[railway=dismantled][!"dismantled:railway"],
 way|z9-[railway=proposed][!"proposed:railway"],
 way|z9-[railway=construction][!"construction:railway"]
 {
@@ -699,6 +700,8 @@ way|z9-[railway=construction][!"construction:railway"]
 	assertNoMatch: "way railway=abandoned abandoned:railway=rail";
 	assertMatch: "way railway=razed";
 	assertNoMatch: "way railway=razed razed:railway=rail";
+	assertMatch: "way railway=dismantled";
+	assertNoMatch: "way railway=dismantled dismantled:railway=rail";
 	assertMatch: "way railway=proposed";
 	assertNoMatch: "way railway=proposed proposed:railway=rail";
 	assertMatch: "way railway=construction";


### PR DESCRIPTION
according to the wiki dismanteld  is equal to razed for railways this pull request changes the validator to support dismanteld:railway
and changes the style to show dismanteld railways the same as razed railways