### PR TITLE
Added Dutch signals to electrified.mapcss

### DIFF
--- a/styles/electrified.mapcss
+++ b/styles/electrified.mapcss
@@ -317,9 +317,11 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricit
 /**************************/
 /* DE power off sign El 1 */
 /* AT Hauptschalter aus   */
+/* NL uitschakelbord 306a */
 /**************************/
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="DE-ESO:el1"]["railway:signal:electricity:type"="power_off"]["railway:signal:electricity:form"="sign"],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="AT-V2:hauptschalter_aus"]["railway:signal:electricity:type"="power_off"]["railway:signal:electricity:form"=sign]
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="AT-V2:hauptschalter_aus"]["railway:signal:electricity:type"="power_off"]["railway:signal:electricity:form"=sign],
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="NL:306a"]["railway:signal:electricity:type"="power_off"]["railway:signal:electricity:form"=sign]
 {
 	z-index: 460;
 	icon-image: "icons/de/el1-14.png";
@@ -341,12 +343,14 @@ node|z17-[railway=signal]["railway:signal:electricity"="DE-AVG:st7"]["railway:si
 	allow-overlap: true;
 }
 
-/**************************/
+/*************************/
 /* DE power on sign El 2 */
-/* AT Hauptschalter ein   */
-/**************************/
+/* AT Hauptschalter ein  */
+/* NL inschakelbord 307a */
+/*************************/
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="DE-ESO:el2"]["railway:signal:electricity:type"="power_on"]["railway:signal:electricity:form"="sign"],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="AT-V2:hauptschalter_ein"]["railway:signal:electricity:type"="power_on"]["railway:signal:electricity:form"=sign]
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="AT-V2:hauptschalter_ein"]["railway:signal:electricity:type"="power_on"]["railway:signal:electricity:form"=sign],
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="NL:307a"]["railway:signal:electricity:type"="power_on"]["railway:signal:electricity:form"=sign]
 {
 	z-index: 458;
 	icon-image: "icons/de/el2-14.png";
@@ -355,12 +359,14 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricit
 	allow-overlap: true;
 }
 
-/*************************************/
-/* DE pantograph down advance El 3   */
-/* AT Ankündigung Stromabnehmer tief */
-/*************************************/
+/********************************************/
+/* DE pantograph down advance El 3          */
+/* AT Ankündigung Stromabnehmer tief        */
+/* NL aankondiging stroomafnemers neer 308a */
+/********************************************/
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="DE-ESO:el3"]["railway:signal:electricity:type"="pantograph_down_advance"]["railway:signal:electricity:form"="sign"],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="AT-V2:andkündigung_stromabnehmer_tief"]["railway:signal:electricity:type"="pantograph_down_advance"]["railway:signal:electricity:form"=sign]
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="AT-V2:andkündigung_stromabnehmer_tief"]["railway:signal:electricity:type"="pantograph_down_advance"]["railway:signal:electricity:form"=sign],
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="NL:308a"]["railway:signal:electricity:type"="pantograph_down_advance"]["railway:signal:electricity:form"=sign]
 {
 	z-index: 440;
 	icon-image: "icons/de/el3-14.png";
@@ -369,12 +375,14 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricit
 	allow-overlap: true;
 }
 
-/***************************/
-/* DE pantograph down El 4 */
-/* AT Stromabnehmer tief   */
-/***************************/
+/*******************************/
+/* DE pantograph down El 4     */
+/* AT Stromabnehmer tief       */
+/* NL stroomafnemers neer 309a */
+/*******************************/
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="DE-ESO:el4"]["railway:signal:electricity:type"="pantograph_down"]["railway:signal:electricity:form"="sign"],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="AT-V2:stromabnehmer_tief"]["railway:signal:electricity:type"="pantograph_down"]["railway:signal:electricity:form"=sign]
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="AT-V2:stromabnehmer_tief"]["railway:signal:electricity:type"="pantograph_down"]["railway:signal:electricity:form"=sign],
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="NL:309a"]["railway:signal:electricity:type"="pantograph_down"]["railway:signal:electricity:form"=sign]
 {
 	z-index: 460;
 	icon-image: "icons/de/el4-14.png";
@@ -383,12 +391,14 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricit
 	allow-overlap: true;
 }
 
-/*************************/
-/* DE pantograph up El 5 */
-/* AT Stromabnehmer hoch */
-/*************************/
+/*****************************/
+/* DE pantograph up El 5     */
+/* AT Stromabnehmer hoch     */
+/* NL stroomafnemers op 310a */
+/*****************************/
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="DE-ESO:el5"]["railway:signal:electricity:type"="pantograph_up"]["railway:signal:electricity:form"="sign"],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="AT-V2:stromabnehmer_hoch"]["railway:signal:electricity:type"="pantograph_up"]["railway:signal:electricity:form"=sign]
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="AT-V2:stromabnehmer_hoch"]["railway:signal:electricity:type"="pantograph_up"]["railway:signal:electricity:form"=sign],
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="NL:310a"]["railway:signal:electricity:type"="pantograph_up"]["railway:signal:electricity:form"=sign]
 {
 	z-index: 458;
 	icon-image: "icons/de/el5-14.png";
@@ -400,9 +410,11 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricit
 /*******************************************************/
 /* DE end of catenary sign El 6                        */
 /* AT Halt für Fahrzeuge mit angehobenem Stromabnehmer */
+/* NL einde bovenleiding                               */
 /*******************************************************/
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="DE-ESO:el6"]["railway:signal:electricity:type"="end_of_catenary"]["railway:signal:electricity:form"="sign"]["railway:signal:electricity:turn_direction"!="left"]["railway:signal:electricity:turn_direction"!="right"],
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="AT-V2:halt_fuer_fahrzeuge_mit_angehobenem_stromabnehmer"]["railway:signal:electricity:type"="end_of_catenary"]["railway:signal:electricity:form"=sign]["railway:signal:electricity:turn_direction"!="left"]["railway:signal:electricity:turn_direction"!="right"]
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="AT-V2:halt_fuer_fahrzeuge_mit_angehobenem_stromabnehmer"]["railway:signal:electricity:type"="end_of_catenary"]["railway:signal:electricity:form"=sign]["railway:signal:electricity:turn_direction"!="left"]["railway:signal:electricity:turn_direction"!="right"],
+node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="NL:311"]["railway:signal:electricity:type"="end_of_catenary"]["railway:signal:electricity:form"="sign"]["railway:signal:electricity:turn_direction"!="left"]["railway:signal:electricity:turn_direction"!="right"]
 {
 	z-index: 450;
 	icon-image: "icons/de/el6-14.png";
@@ -425,10 +437,10 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricit
 	allow-overlap: true;
 }
 
-/*********************************************************************/
+/********************************************************************/
 /* DE end of catenary sign El 6 + arrow left                        */
 /* AT Halt für Fahrzeuge mit angehobenem Stromabnehmer + arrow left */
-/*********************************************************************/
+/********************************************************************/
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="DE-ESO:el6"]["railway:signal:electricity:type"="end_of_catenary"]["railway:signal:electricity:form"="sign"]["railway:signal:electricity:turn_direction"="left"],
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:electricity"="AT-V2:halt_fuer_fahrzeuge_mit_angehobenem_stromabnehmer"]["railway:signal:electricity:type"="end_of_catenary"]["railway:signal:electricity:form"=sign]["railway:signal:electricity:turn_direction"="left"]
 {


### PR DESCRIPTION
The Netherlands has electrification signs that are the same to those of Germany and Austria. This PR adds the Dutch signal tags to those signs that were already in the electrified.mapcss file, in accordance with the [Dutch workrules](http://www.saferail.nl/NLW/NLWDOCS/RSV-bijlage04_Seinreglement_geintegreerde%20versie%20per%2001.12.2012.pdf). Example: 
DE `["railway:signal:electricity"="DE-ESO:el2"]` NL `["railway:signal:electricity"="NL:307a"]`.