### PR TITLE
define available translations only at one place

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -186,6 +186,8 @@
 
 	function urlArgsToParam($checkMobile, $urlbase)
 	{
+		global $langs;
+
 		echo "<script type=\"text/javascript\">\n";
 			echo "var params={\n";
 			echo "urlbase : '" . $urlbase . "',\n";
@@ -211,7 +213,8 @@
 			echo "operator : " . (isset($_GET['operator']) ? (json_encode($_GET['operator'])) : ("null")) . ",\n";
 			if ($checkMobile)
 				echo "mobile : " . (isset($_GET['mobile']) ? (($_GET['mobile'] != '0' && $_GET['mobile'] != 'false') ? "true" : "false") : ("null")) . ",\n";
-			echo "style : " . (isset($_GET['style']) ? (json_encode($_GET['style'])) : ("null")) . "\n";
+			echo "style : " . (isset($_GET['style']) ? (json_encode($_GET['style'])) : ("null")) . ",\n";
+			echo "availableTranslations : " . json_encode($langs) . "\n";
 			echo "};\n";
 		echo "</script>\n";
 	}

--- a/js/bitmap-map.js
+++ b/js/bitmap-map.js
@@ -16,31 +16,6 @@ window.openrailwaymap = {
 		"signals": "Signalling",
 		"electrified": "Electrification (beta)",
 		"gauge": "Track gauge (beta)",
-	},
-	'availableTranslations': {
-		"ca": "ca_ES",
-		"cs": "cs_CZ",
-		"da": "da_DK",
-		"de": "de_DE",
-		"el": "el_GR",
-		"en": "en_GB",
-		"es": "es_ES",
-		"fi": "fi_FI",
-		"fr": "fr_FR",
-		"hu": "hu_HU",
-		"ja": "ja_JP",
-		"lt": "lt_LT",
-		"nl": "nl_NL",
-		"nqo": "nqo_GN",
-		"pl": "pl_PL",
-		"pt": "pt_PT",
-		"ru": "ru_RU",
-		"sl": "sl_SI",
-		"sv": "sv_SE",
-		"tr": "tr_TR",
-		"uk": "uk_UA",
-		"vi": "vi_VN",
-		"zh": "zh_TW"
 	}
 };
 

--- a/js/functions.js
+++ b/js/functions.js
@@ -5,13 +5,12 @@ This is free software, and you are welcome to redistribute it under certain cond
 See https://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 */
 
-
 // returns the lang-region-code that fits the best to the user
 function getUserLang()
 {
 	// override browser settings when language is set in url
-	if (window.openrailwaymap.availableTranslations.hasOwnProperty(params['lang']))
-		return window.openrailwaymap.availableTranslations[params['lang']];
+	if (params['availableTranslations'].hasOwnProperty(params['lang']))
+		return params['availableTranslations'][params['lang']][0];
 
 	var lang = navigator.language || navigator.userLanguage || 'en-GB';
 	var languages = navigator.languages || [lang];
@@ -20,14 +19,15 @@ function getUserLang()
 	{
 		// lang-country combination as first choice
 		var langcountrycode = languages[i].replace('-', '_');
-		for (var key in window.openrailwaymap.availableTranslations)
-			if (window.openrailwaymap.availableTranslations.hasOwnProperty(key) && window.openrailwaymap.availableTranslations[key] === langcountrycode)
+		for (var key in params['availableTranslations']) {
+			if (params['availableTranslations'].hasOwnProperty(key) && params['availableTranslations'][key][0] === langcountrycode)
 				return langcountrycode;
+		}
 
 		// only lang as second choice
 		var langcode = langcountrycode.split('_')[0];
-		if (window.openrailwaymap.availableTranslations.hasOwnProperty(langcode))
-			return window.openrailwaymap.availableTranslations[langcode];
+		if (params['availableTranslations'].hasOwnProperty(langcode))
+			return params['availableTranslations'][langcode][0];
 	}
 
 	return 'en_GB';

--- a/js/mobile.js
+++ b/js/mobile.js
@@ -16,31 +16,6 @@ window.openrailwaymap = {
 		"signals": "Signalling",
 		"electrified": "Electrification (beta)",
 		"gauge": "Track gauge (beta)",
-	},
-	'availableTranslations': {
-		"ca": "ca_ES",
-		"cs": "cs_CZ",
-		"da": "da_DK",
-		"de": "de_DE",
-		"el": "el_GR",
-		"en": "en_GB",
-		"es": "es_ES",
-		"fi": "fi_FI",
-		"hu": "hu_HU",
-		"fr": "fr_FR",
-		"ja": "ja_JP",
-		"lt": "lt_LT",
-		"nl": "nl_NL",
-		"nqo": "nqo_GN",
-		"pl": "pl_PL",
-		"pt": "pt_PT",
-		"ru": "ru_RU",
-		"sl": "sl_SI",
-		"sv": "sv_SE",
-		"tr": "tr_TR",
-		"uk": "uk_UA",
-		"vi": "vi_VN",
-		"zh": "zh_TW"
 	}
 };
 


### PR DESCRIPTION
The PHP code already has this list, so just pass it down to JavaScript instead of defining it 3 times again.