### PR TITLE
Update leaflet.js and use css for grayscaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,3 @@ download/
 css/Leaflet.EditInOSM.css
 img/edit-in-osm.png
 js/Leaflet.EditInOSM.js
-
-js/L.TileLayer.Grayscale.js

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 SHELL = /bin/sh -e
-DEP_LEAFLET_VERSION = 0.7.7
+DEP_LEAFLET_VERSION = 1.7.1
 DEP_LEAFLET_EDITOR_FILES = download/Leaflet.EditInOSM.js download/Leaflet.EditInOSM.css download/edit-in-osm.png
-DEP_LEAFLET_GRAYSCALE_VERSION = 8675605f71f856299ebdd05a635ba1494817f5ff
 
 .PHONY: check all
 
@@ -39,11 +38,6 @@ $(DEP_LEAFLET_EDITOR_FILES):
 	wget -O $@.tmp https://raw.githubusercontent.com/yohanboniface/Leaflet.EditInOSM/master/$(notdir $@)
 	mv $@.tmp $@
 
-download/TileLayer.Grayscale.js:
-	mkdir -p download
-	wget -O $@.tmp https://raw.githubusercontent.com/Zverik/leaflet-grayscale/$(DEP_LEAFLET_GRAYSCALE_VERSION)/$(notdir $@)
-	mv $@.tmp $@
-
 download-deps:	download/leaflet-$(DEP_LEAFLET_VERSION).tar.gz \
 		$(DEP_LEAFLET_EDITOR_FILES)
 
@@ -57,7 +51,4 @@ css/Leaflet.EditInOSM.css: $(DEP_LEAFLET_EDITOR_FILES)
 	sed 's#"./edit-in-osm#"../img/edit-in-osm#' download/Leaflet.EditInOSM.css > download/Leaflet.EditInOSM.css_
 	mv download/Leaflet.EditInOSM.css_ $@
 
-js/L.TileLayer.Grayscale.js: download/TileLayer.Grayscale.js
-	cp download/TileLayer.Grayscale.js js/L.TileLayer.Grayscale.js
-
-install-deps: css/leaflet.css css/Leaflet.EditInOSM.css js/L.TileLayer.Grayscale.js
+install-deps: css/leaflet.css css/Leaflet.EditInOSM.css

--- a/css/map.css
+++ b/css/map.css
@@ -613,10 +613,10 @@ noscript p
 #locateButton
 {
 	position: absolute;
-	left: 310px;
-	top: 70px;
-	width: 26px;
-	height: 26px;
+	left: 312px;
+	top: 80px;
+	width: 30px;
+	height: 30px;
 	background-color: white;
 	background-image: url('../img/locate.png');
 	background-repeat: no-repeat;
@@ -685,4 +685,9 @@ noscript p
 {
 	margin-left: 5px;
 	margin-top: 10px;
+}
+
+.leaflet-tile-pane-grayscale {
+	-webkit-filter: grayscale(100%);
+	filter: grayscale(100%);
 }

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -148,10 +148,10 @@ noscript p
 #locateButton
 {
 	position: absolute;
-	left: 9px;
-	top: 110px;
-	width: 26px;
-	height: 26px;
+	left: 11px;
+	top: 120px;
+	width: 30px;
+	height: 30px;
 	background-color: white;
 	background-image: url('../img/locate.png');
 	background-repeat: no-repeat;
@@ -411,4 +411,9 @@ noscript p
 	margin-top: 20px;
 	margin-bottom: 20px;
 	width: 50px;
+}
+
+.leaflet-tile-pane-grayscale {
+	-webkit-filter: grayscale(100%);
+	filter: grayscale(100%);
 }

--- a/embed.php
+++ b/embed.php
@@ -40,7 +40,6 @@
 		<link rel="stylesheet" type="text/css" href="css/leaflet.css" />
 
 		<script type="text/javascript" src="js/leaflet.js"></script>
-		<script type="text/javascript" src="js/L.TileLayer.Grayscale.js"></script>
 		<?php
 			urlArgsToParam(false, $urlbase);
 		?>

--- a/index.php
+++ b/index.php
@@ -49,7 +49,6 @@
 		<script type="text/javascript" src="js/leaflet.js"></script>
 		<link rel="stylesheet" href="css/Leaflet.EditInOSM.css" />
 		<script src="js/Leaflet.EditInOSM.js"></script>
-		<script type="text/javascript" src="js/L.TileLayer.Grayscale.js"></script>
 		<?php
 			urlArgsToParam(true, $urlbase);
 		?>

--- a/js/functions.js
+++ b/js/functions.js
@@ -256,10 +256,11 @@ function mobileRedirection()
 function setupControls()
 {
 	// grayscale mapnik background layer
-	var mapnikGray = new L.TileLayer.Grayscale('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+	var mapnikGray = new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 	{
 		attribution: _("Map data &copy; OpenStreetMap contributors"),
-		maxZoom: 19
+		maxZoom: 19,
+		className: 'leaflet-tile-pane-grayscale'
 	}).addTo(map);
 	// normal mapnik background layer
 	var mapnik = new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',

--- a/mobile.php
+++ b/mobile.php
@@ -49,7 +49,6 @@
 		<script type="text/javascript" src="js/leaflet.js"></script>
 		<link rel="stylesheet" href="css/Leaflet.EditInOSM.css" />
 		<script src="js/Leaflet.EditInOSM.js"></script>
-		<script type="text/javascript" src="js/L.TileLayer.Grayscale.js"></script>
 		<script>L_DISABLE_3D = true;</script>
 
 		<?php


### PR DESCRIPTION
The grayscale plugin seems unmaintained and for adding custom css classes a leaflet update was needed. The CSS filter might not work with IE11 and in general this needs more testing with different browsers.