### PR TITLE
use eval expressions for speed signal icons

### DIFF
--- a/styles/maxspeed.mapcss
+++ b/styles/maxspeed.mapcss
@@ -252,19 +252,10 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=~/^([1-9]|1[0-6])0$/]
 {
 	z-index: eval(95 + tag("railway:signal:speed_limit_distant:speed")/2);
+	icon-image: eval(concat("icons/de/zs3v-", tag("railway:signal:speed_limit_distant:speed"), "-sign-down-44.png"));
 	icon-width: 22;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=10]
-{
-	icon-image: "icons/de/zs3v-10-sign-down-44.png";
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=20]
-{
-	icon-image: "icons/de/zs3v-20-sign-down-44.png";
 }
 
 /* German speed signals (Zs 3v) as light signals */
@@ -277,11 +268,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=30]
-{
-	icon-image: "icons/de/zs3v-30-sign-down-44.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=30]
 {
 	z-index: 110;
@@ -298,11 +284,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=40]
-{
-	icon-image: "icons/de/zs3v-40-sign-down-44.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=40]
@@ -314,11 +295,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=50]
-{
-	icon-image: "icons/de/zs3v-50-sign-down-44.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=50]
 {
 	z-index: 120;
@@ -326,11 +302,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=60]
-{
-	icon-image: "icons/de/zs3v-60-sign-down-44.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=60]
@@ -342,11 +313,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=70]
-{
-	icon-image: "icons/de/zs3v-70-sign-down-44.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=70]
 {
 	z-index: 130;
@@ -354,11 +320,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=80]
-{
-	icon-image: "icons/de/zs3v-80-sign-down-44.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=80]
@@ -370,11 +331,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=90]
-{
-	icon-image: "icons/de/zs3v-90-sign-down-44.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=90]
 {
 	z-index: 140;
@@ -382,11 +338,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=100]
-{
-	icon-image: "icons/de/zs3v-100-sign-down-44.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=100]
@@ -398,11 +349,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=110]
-{
-	icon-image: "icons/de/zs3v-110-sign-down-44.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=110]
 {
 	z-index: 150;
@@ -410,11 +356,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=120]
-{
-	icon-image: "icons/de/zs3v-120-sign-down-44.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=120]
@@ -426,48 +367,14 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=130]
-{
-	icon-image: "icons/de/zs3v-130-sign-down-44.png";
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=140]
-{
-	icon-image: "icons/de/zs3v-140-sign-down-44.png";
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=150]
-{
-	icon-image: "icons/de/zs3v-150-sign-down-44.png";
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=160]
-{
-	icon-image: "icons/de/zs3v-160-sign-down-44.png";
-}
-
 /* Austrian speed signals (Geschwindigkeitsvoranzeiger) as signs */
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=~/^([1-9]|10)0$/]
 {
 	z-index: eval(95 + tag("railway:signal:speed_limit_distant:speed")/2);
+	icon-image: eval(concat("icons/at/geschwindigkeitsvoranzeiger-", tag("railway:signal:speed_limit_distant:speed"), "-sign-44.png"));
 	icon-width: 22;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=10]
-{
-	icon-image: "icons/at/geschwindigkeitsvoranzeiger-10-sign-44.png";
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=20]
-{
-	icon-image: "icons/at/geschwindigkeitsvoranzeiger-20-sign-44.png";
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=30]
-{
-	icon-image: "icons/at/geschwindigkeitsvoranzeiger-30-sign-44.png";
 }
 
 /* Austrian speed signals (Geschwindigkeitsvoranzeiger) as light signals */
@@ -480,11 +387,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=40]
-{
-	icon-image: "icons/at/geschwindigkeitsvoranzeiger-40-sign-44.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=40]
 {
 	z-index: 115;
@@ -492,11 +394,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 14;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=50]
-{
-	icon-image: "icons/at/geschwindigkeitsvoranzeiger-50-sign-44.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=50]
@@ -508,11 +405,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=60]
-{
-	icon-image: "icons/at/geschwindigkeitsvoranzeiger-60-sign-44.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=60]
 {
 	z-index: 125;
@@ -520,11 +412,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 14;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=70]
-{
-	icon-image: "icons/at/geschwindigkeitsvoranzeiger-70-sign-44.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=70]
@@ -536,11 +423,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=80]
-{
-	icon-image: "icons/at/geschwindigkeitsvoranzeiger-80-sign-44.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=80]
 {
 	z-index: 135;
@@ -550,11 +432,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=90]
-{
-	icon-image: "icons/at/geschwindigkeitsvoranzeiger-90-sign-44.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=90]
 {
 	z-index: 140;
@@ -562,11 +439,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 14;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=100]
-{
-	icon-image: "icons/at/geschwindigkeitsvoranzeiger-100-sign-44.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:geschwindigkeitvorsanzeiger"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=100]
@@ -591,19 +463,10 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=~/^([1-9]|1[0-6])0$/]
 {
 	z-index: eval(195 + tag("railway:signal:speed_limit:speed")/2);
+	icon-image: eval(concat("icons/de/zs3-", tag("railway:signal:speed_limit:speed"), "-sign-up-44.png"));
 	icon-width: 22;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=10]
-{
-	icon-image: "icons/de/zs3-10-sign-up-44.png";
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=20]
-{
-	icon-image: "icons/de/zs3-20-sign-up-44.png";
 }
 
 /* German speed signals (Zs 3) as light signals*/
@@ -616,11 +479,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=30]
-{
-	icon-image: "icons/de/zs3-30-sign-up-44.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=30]
 {
 	z-index: 210;
@@ -628,11 +486,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=40]
-{
-	icon-image: "icons/de/zs3-40-sign-up-44.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=40]
@@ -644,11 +497,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=50]
-{
-	icon-image: "icons/de/zs3-50-sign-up-44.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=50]
 {
 	z-index: 220;
@@ -656,11 +504,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=60]
-{
-	icon-image: "icons/de/zs3-60-sign-up-44.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=60]
@@ -672,11 +515,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=70]
-{
-	icon-image: "icons/de/zs3-70-sign-up-44.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=70]
 {
 	z-index: 230;
@@ -684,11 +522,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=80]
-{
-	icon-image: "icons/de/zs3-80-sign-up-44.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=80]
@@ -700,11 +533,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=90]
-{
-	icon-image: "icons/de/zs3-90-sign-up-44.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=90]
 {
 	z-index: 240;
@@ -712,11 +540,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=100]
-{
-	icon-image: "icons/de/zs3-100-sign-up-44.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=100]
@@ -728,11 +551,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=110]
-{
-	icon-image: "icons/de/zs3-110-sign-up-44.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=110]
 {
 	z-index: 250;
@@ -740,11 +558,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=120]
-{
-	icon-image: "icons/de/zs3-120-sign-up-44.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=120]
@@ -756,48 +569,14 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=130]
-{
-	icon-image: "icons/de/zs3-130-sign-up-44.png";
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=140]
-{
-	icon-image: "icons/de/zs3-140-sign-up-44.png";
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=150]
-{
-	icon-image: "icons/de/zs3-150-sign-up-44.png";
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:zs3"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=160]
-{
-	icon-image: "icons/de/zs3-160-sign-up-44.png";
-}
-
 /* Austrian speed signals (Geschwindigkeitsanzeiger)*/
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=~/^([1-9]|1[0-26])0$/]
 {
 	z-index: eval(195 + tag("railway:signal:speed_limit:speed")/2);
+	icon-image: eval(concat("icons/at/geschwindigkeitsanzeiger-", tag("railway:signal:speed_limit:speed"), "-sign-28.png"));
 	icon-width: 14;
 	icon-height: 14;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=10]
-{
-	icon-image: "icons/at/geschwindigkeitsanzeiger-10-sign-28.png";
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=20]
-{
-	icon-image: "icons/at/geschwindigkeitsanzeiger-20-sign-28.png";
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=30]
-{
-	icon-image: "icons/at/geschwindigkeitsanzeiger-30-sign-28.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=30]
@@ -809,11 +588,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=40]
-{
-	icon-image: "icons/at/geschwindigkeitsanzeiger-40-sign-28.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=40]
 {
 	z-index: 215;
@@ -821,11 +595,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 14;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=50]
-{
-	icon-image: "icons/at/geschwindigkeitsanzeiger-50-sign-28.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=50]
@@ -837,11 +606,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=60]
-{
-	icon-image: "icons/at/geschwindigkeitsanzeiger-60-sign-28.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=60]
 {
 	z-index: 225;
@@ -849,11 +613,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 14;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=70]
-{
-	icon-image: "icons/at/geschwindigkeitsanzeiger-70-sign-28.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=70]
@@ -865,11 +624,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=80]
-{
-	icon-image: "icons/at/geschwindigkeitsanzeiger-80-sign-28.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=80]
 {
 	z-index: 235;
@@ -877,11 +631,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 14;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=90]
-{
-	icon-image: "icons/at/geschwindigkeitsanzeiger-90-sign-28.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=90]
@@ -893,11 +642,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=100]
-{
-	icon-image: "icons/at/geschwindigkeitsanzeiger-100-sign-28.png";
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=100]
 {
 	z-index: 245;
@@ -905,16 +649,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-width: 14;
 	icon-height: 14;
 	allow-overlap: true;
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=110]
-{
-	icon-image: "icons/at/geschwindigkeitsanzeiger-110-sign-28.png";
-}
-
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=120]
-{
-	icon-image: "icons/at/geschwindigkeitsanzeiger-120-sign-28.png";
 }
 
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=light]["railway:signal:speed_limit:speed"~=120]
@@ -926,299 +660,43 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitsanzeiger"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=160]
-{
-	icon-image: "icons/at/geschwindigkeitsanzeiger-160-sign-28.png";
-}
-
 /* West German branch line speed signals (Lf 4 DS 301) */
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:db:lf4"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=~/^([2-8]0|1[05]|0)$/]
 {
 	z-index: eval(295 + tag("railway:signal:speed_limit_distant:speed")/2);
+	icon-image: eval(concat("icons/de/lf4-ds301-", tag("railway:signal:speed_limit_distant:speed"), "-sign-down-44.png"));
 	icon-width: 22;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:db:lf4"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=0]
-{
-	icon-image: "icons/de/lf4-ds301-0-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:db:lf4"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=10]
-{
-	icon-image: "icons/de/lf4-ds301-10-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:db:lf4"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=15]
-{
-	icon-image: "icons/de/lf4-ds301-15-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:db:lf4"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=20]
-{
-	icon-image: "icons/de/lf4-ds301-20-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:db:lf4"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=30]
-{
-	icon-image: "icons/de/lf4-ds301-30-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:db:lf4"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=40]
-{
-	icon-image: "icons/de/lf4-ds301-40-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:db:lf4"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=50]
-{
-	icon-image: "icons/de/lf4-ds301-50-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:db:lf4"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=60]
-{
-	icon-image: "icons/de/lf4-ds301-60-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:db:lf4"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=70]
-{
-	icon-image: "icons/de/lf4-ds301-70-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:db:lf4"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=80]
-{
-	icon-image: "icons/de/lf4-ds301-80-sign-down-44.png";
 }
 
 /* German line speed signals (Lf 6) */
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=~/^((1?[1-9]|[12]0)0|5|15)$/]
 {
 	z-index: eval(295 + tag("railway:signal:speed_limit_distant:speed")/2);
+	icon-image: eval(concat("icons/de/lf6-", tag("railway:signal:speed_limit_distant:speed"), "-sign-down-44.png"));
 	icon-width: 22;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=5]
-{
-	icon-image: "icons/de/lf6-5-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=15]
-{
-	icon-image: "icons/de/lf6-15-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=10]
-{
-	icon-image: "icons/de/lf6-10-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=20]
-{
-	icon-image: "icons/de/lf6-20-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=30]
-{
-	icon-image: "icons/de/lf6-30-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=40]
-{
-	icon-image: "icons/de/lf6-40-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=50]
-{
-	icon-image: "icons/de/lf6-50-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=60]
-{
-	icon-image: "icons/de/lf6-60-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=70]
-{
-	icon-image: "icons/de/lf6-70-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=80]
-{
-	icon-image: "icons/de/lf6-80-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=90]
-{
-	icon-image: "icons/de/lf6-90-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=100]
-{
-	icon-image: "icons/de/lf6-100-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=110]
-{
-	icon-image: "icons/de/lf6-110-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=120]
-{
-	icon-image: "icons/de/lf6-120-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=130]
-{
-	icon-image: "icons/de/lf6-130-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=140]
-{
-	icon-image: "icons/de/lf6-140-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=150]
-{
-	icon-image: "icons/de/lf6-150-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=160]
-{
-	icon-image: "icons/de/lf6-160-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=170]
-{
-	icon-image: "icons/de/lf6-170-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=180]
-{
-	icon-image: "icons/de/lf6-180-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=190]
-{
-	icon-image: "icons/de/lf6-190-sign-down-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:lf6"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=200]
-{
-	icon-image: "icons/de/lf6-200-sign-down-44.png";
 }
 
 /* Austrian line speed signals (Ankündigungstafel) */
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:ankündigungstafel"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=~/^(1?[1-9]|[12]0)0$/]
 {
 	z-index: eval(295 + tag("railway:signal:speed_limit_distant:speed")/2);
+	icon-image: eval(concat("icons/at/ankuendigungstafel-", tag("railway:signal:speed_limit_distant:speed"), "-sign-44.png"));
 	icon-width: 22;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:ankündigungstafel"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=10]
-{
-	icon-image: "icons/at/ankuendigungstafel-10-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:ankündigungstafel"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=20]
-{
-	icon-image: "icons/at/ankuendigungstafel-20-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:ankündigungstafel"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=30]
-{
-	icon-image: "icons/at/ankuendigungstafel-30-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:ankündigungstafel"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=40]
-{
-	icon-image: "icons/at/ankuendigungstafel-40-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:ankündigungstafel"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=50]
-{
-	icon-image: "icons/at/ankuendigungstafel-50-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:ankündigungstafel"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=60]
-{
-	icon-image: "icons/at/ankuendigungstafel-60-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:ankündigungstafel"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=70]
-{
-	icon-image: "icons/at/ankuendigungstafel-70-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:ankündigungstafel"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=80]
-{
-	icon-image: "icons/at/ankuendigungstafel-80-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:ankündigungstafel"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=90]
-{
-	icon-image: "icons/at/ankuendigungstafel-90-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:ankündigungstafel"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=100]
-{
-	icon-image: "icons/at/ankuendigungstafel-100-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:ankündigungstafel"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=110]
-{
-	icon-image: "icons/at/ankuendigungstafel-110-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:ankündigungstafel"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=120]
-{
-	icon-image: "icons/at/ankuendigungstafel-120-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:ankündigungstafel"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=130]
-{
-	icon-image: "icons/at/ankuendigungstafel-130-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="AT-V2:ankündigungstafel"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=140]
-{
-	icon-image: "icons/at/ankuendigungstafel-140-sign-44.png";
 }
 
 node|z14-[railway=signal]["railway:signal:speed_limit_distant"="DE-HHA:l1"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=~/^[3-7]0$/]
 {
 	z-index: eval(295 + tag("railway:signal:speed_limit_distant:speed")/2);
+	icon-image: eval(concat("icons/de/hha/l1-", tag("railway:signal:speed_limit_distant:speed"), "-sign-44.png"));
 	icon-width: 22;
 	icon-height: 19;
 	allow-overlap: true;
-}
-
-node|z14-[railway=signal]["railway:signal:speed_limit_distant"="DE-HHA:l1"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=30]
-{
-	icon-image: "icons/de/hha/l1-30-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:speed_limit_distant"="DE-HHA:l1"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=40]
-{
-	icon-image: "icons/de/hha/l1-40-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:speed_limit_distant"="DE-HHA:l1"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=50]
-{
-	icon-image: "icons/de/hha/l1-50-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:speed_limit_distant"="DE-HHA:l1"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=60]
-{
-	icon-image: "icons/de/hha/l1-60-sign-44.png";
-}
-
-node|z14-[railway=signal]["railway:signal:speed_limit_distant"="DE-HHA:l1"]["railway:signal:speed_limit_distant:form"=sign]["railway:signal:speed_limit_distant:speed"=70]
-{
-	icon-image: "icons/de/hha/l1-70-sign-44.png";
 }
 
 node|z15-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-BOStrab:g3"]["railway:signal:speed_limit:form"=sign]
@@ -1414,253 +892,20 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=~/^((1?[1-9]|[12]0)0|5|15)$/]
 {
 	z-index: eval(395 + tag("railway:signal:speed_limit:speed")/2);
+	icon-image: eval(concat("icons/de/lf7-", tag("railway:signal:speed_limit:speed"), "-sign-32.png"));
 	icon-width: 13;
 	icon-height: 16;
 	allow-overlap: true;
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=5]
-{
-	icon-image: "icons/de/lf7-5-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=15]
-{
-	icon-image: "icons/de/lf7-15-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=10]
-{
-	icon-image: "icons/de/lf7-10-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=20]
-{
-	icon-image: "icons/de/lf7-20-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=30]
-{
-	icon-image: "icons/de/lf7-30-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=40]
-{
-	icon-image: "icons/de/lf7-40-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=50]
-{
-	icon-image: "icons/de/lf7-50-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=60]
-{
-	icon-image: "icons/de/lf7-60-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=70]
-{
-	icon-image: "icons/de/lf7-70-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=80]
-{
-	icon-image: "icons/de/lf7-80-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=90]
-{
-	icon-image: "icons/de/lf7-90-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=100]
-{
-	icon-image: "icons/de/lf7-100-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=110]
-{
-	icon-image: "icons/de/lf7-110-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=120]
-{
-	icon-image: "icons/de/lf7-120-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=130]
-{
-	icon-image: "icons/de/lf7-130-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=140]
-{
-	icon-image: "icons/de/lf7-140-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=150]
-{
-	icon-image: "icons/de/lf7-150-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=160]
-{
-	icon-image: "icons/de/lf7-160-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=170]
-{
-	icon-image: "icons/de/lf7-170-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=180]
-{
-	icon-image: "icons/de/lf7-180-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=190]
-{
-	icon-image: "icons/de/lf7-190-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="DE-ESO:lf7"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=200]
-{
-	icon-image: "icons/de/lf7-200-sign-32.png";
 }
 
 /* Austrian line speed signals (Geschwindigkeitstafel) */
 node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=~/^[1-9][05]|1[0-6]0$/]
 {
 	z-index: eval(395 + tag("railway:signal:speed_limit:speed")/2);
+	icon-image: eval(concat("icons/at/geschwindigkeitstafel-", tag("railway:signal:speed_limit:speed"), "-sign-32.png"));
 	icon-width: 16;
 	icon-height: 16;
 	allow-overlap: true;
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=10]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-10-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=15]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-15-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=20]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-20-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=25]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-25-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=30]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-30-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=35]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-35-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=40]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-40-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=45]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-45-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=50]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-50-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=55]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-55-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=60]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-60-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=65]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-65-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=70]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-70-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=75]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-75-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=80]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-80-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=85]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-85-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=90]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-90-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=95]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-95-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=100]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-100-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=110]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-110-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=120]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-120-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=130]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-130-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=140]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-140-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=150]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-150-sign-32.png";
-}
-
-node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit"="AT-V2:geschwindigkeitstafel"]["railway:signal:speed_limit:form"=sign]["railway:signal:speed_limit:speed"=160]
-{
-	icon-image: "icons/at/geschwindigkeitstafel-160-sign-32.png";
 }
 
 node|z14-[railway=signal]["railway:signal:speed_limit"="DE-HHA:l4"]["railway:signal:speed_limit:form"=sign]

--- a/styles/maxspeed.mapcss
+++ b/styles/maxspeed.mapcss
@@ -277,15 +277,6 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	allow-overlap: true;
 }
 
-node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=30]
-{
-	z-index: 110;
-	icon-image: "icons/de/zs3v-30-light-38.png";
-	icon-width: 14;
-	icon-height: 19;
-	allow-overlap: true;
-}
-
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limit_distant"="DE-ESO:zs3v"]["railway:signal:speed_limit_distant:form"=light]["railway:signal:speed_limit_distant:speed"~=40]
 {
 	z-index: 115;


### PR DESCRIPTION
This is not done for light signals as they can have multiple states and we want to show the highest supported value for them.
    
This did not work with the old rendering stack as mapcss_converter does not support all types of ```eval()``` expressions, but JOSM does.
