### PR TITLE
MOD: Reorganization and cleanup of Signalling legend items

### DIFF
--- a/css/legend.css
+++ b/css/legend.css
@@ -24,7 +24,7 @@ td
 
 td:first-child
 {
-	width: 80px;
+	width: 40px;
 	height: 16px;
 }
 

--- a/legend-generator.php
+++ b/legend-generator.php
@@ -53,7 +53,7 @@
 				$height = '16';
 			}
 
-			return $line . '><canvas width="80" height="' . $height . '" id="legend-' . $index
+			return $line . '><canvas width="40" height="' . $height . '" id="legend-' . $index
 					. '" data-geojson=' . "'" . $payload
 					. "'></canvas></td>\n\t\t\t\t<td>"
 					. htmlspecialchars(_($caption)) . "</td></tr>\n";

--- a/locales/ca_ES/LC_MESSAGES/messages.po
+++ b/locales/ca_ES/LC_MESSAGES/messages.po
@@ -782,13 +782,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr ""
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/cs_CZ/LC_MESSAGES/messages.po
+++ b/locales/cs_CZ/LC_MESSAGES/messages.po
@@ -787,13 +787,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr "Copyright a ochrana osobních údajů"
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/da_DK/LC_MESSAGES/messages.po
+++ b/locales/da_DK/LC_MESSAGES/messages.po
@@ -779,13 +779,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr ""
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/de_DE/LC_MESSAGES/messages.po
+++ b/locales/de_DE/LC_MESSAGES/messages.po
@@ -785,13 +785,13 @@ msgstr "Zs 3 Geschwindigkeits­anzeiger (Tafel, Lichtsignal)"
 msgid "Imprint &amp; Privacy Policy"
 msgstr "Impressum &amp; Datenschutz"
 
-msgid "automatische treinbeïnvloeding"
-msgstr "Automatische Zugbeeinflussung (ATV)"
+msgid "ATB - Automatische Treinbeïnvloeding"
+msgstr "ATB - Automatische Zugbeeinflussung"
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/el_GR/LC_MESSAGES/messages.po
+++ b/locales/el_GR/LC_MESSAGES/messages.po
@@ -780,13 +780,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr ""
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/en_GB/LC_MESSAGES/messages.po
+++ b/locales/en_GB/LC_MESSAGES/messages.po
@@ -778,13 +778,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr "Imprint &amp; Privacy Policy"
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/es_ES/LC_MESSAGES/messages.po
+++ b/locales/es_ES/LC_MESSAGES/messages.po
@@ -781,13 +781,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr ""
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr "Transmisión Vía-Máquina (TVM)"
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr "Control de Velocidad por Balizas (KVB)"
 
 msgid "1067mm"

--- a/locales/fi_FI/LC_MESSAGES/messages.po
+++ b/locales/fi_FI/LC_MESSAGES/messages.po
@@ -778,13 +778,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr ""
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/fr_FR/LC_MESSAGES/messages.po
+++ b/locales/fr_FR/LC_MESSAGES/messages.po
@@ -781,14 +781,14 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr ""
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
-msgstr "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
+msgstr "TVM - Transmission Voie-Machine"
 
-msgid "Contrôle de vitesse par balises (KVB)"
-msgstr "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
+msgstr "KVB - Contrôle de Vitesse par Balises"
 
 msgid "1067mm"
 msgstr "1067mm"

--- a/locales/hu_HU/LC_MESSAGES/messages.po
+++ b/locales/hu_HU/LC_MESSAGES/messages.po
@@ -779,13 +779,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr "Impresszum &amp; Adatvédelmi irányelvek"
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/ja_JP/LC_MESSAGES/messages.po
+++ b/locales/ja_JP/LC_MESSAGES/messages.po
@@ -775,13 +775,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr ""
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/lt_LT/LC_MESSAGES/messages.po
+++ b/locales/lt_LT/LC_MESSAGES/messages.po
@@ -786,13 +786,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr ""
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -774,13 +774,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr ""
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/nl_NL/LC_MESSAGES/messages.po
+++ b/locales/nl_NL/LC_MESSAGES/messages.po
@@ -779,14 +779,14 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr "Uitgever &amp; Privacyverklaring"
 
-msgid "automatische treinbeïnvloeding (ATB)"
-msgstr "automatische treinbeïnvloeding (ATB)"
+msgid "ATB - Automatische Treinbeïnvloeding (ATB)"
+msgstr "ATB - Automatische Treinbeïnvloeding (ATB)"
 
-msgid "Transmission voie-machine (TVM)"
-msgstr "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
+msgstr "TVM - Transmission Voie-Machine"
 
-msgid "Contrôle de vitesse par balises (KVB)"
-msgstr "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
+msgstr "KVB - Contrôle de Vitesse par Balises"
 
 msgid "1067mm"
 msgstr "1067 mm"

--- a/locales/nqo_GN/LC_MESSAGES/messages.po
+++ b/locales/nqo_GN/LC_MESSAGES/messages.po
@@ -776,13 +776,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr ""
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/pl_PL/LC_MESSAGES/messages.po
+++ b/locales/pl_PL/LC_MESSAGES/messages.po
@@ -794,14 +794,14 @@ msgstr "Wskaźnik/sygnalizator ograniczenia prędkości Zs 3"
 msgid "Imprint &amp; Privacy Policy"
 msgstr "Informacje prawne &amp; Polityka prywatności"
 
-msgid "automatische treinbeïnvloeding"
-msgstr "automatyczny system zabezpieczenia pociągu"
+msgid "ATB - Automatische Treinbeïnvloeding"
+msgstr "ATB - Automatyczny system zabezpieczenia pociągu"
 
-msgid "Transmission voie-machine (TVM)"
-msgstr "Transmisja tor‐pojazd (TVM)"
+msgid "TVM - Transmission Voie-Machine"
+msgstr "TVM - Transmisja tor‐pojazd"
 
-msgid "Contrôle de vitesse par balises (KVB)"
-msgstr "Kontrola prędkości KVB"
+msgid "KVB - Contrôle de Vitesse par Balises"
+msgstr "KVB - Kontrola prędkości"
 
 msgid "1067mm"
 msgstr "1067 mm"

--- a/locales/pt_PT/LC_MESSAGES/messages.po
+++ b/locales/pt_PT/LC_MESSAGES/messages.po
@@ -778,13 +778,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr ""
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/ru_RU/LC_MESSAGES/messages.po
+++ b/locales/ru_RU/LC_MESSAGES/messages.po
@@ -798,13 +798,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr "Сведения &amp; Политика конфиденциальности"
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/sl_SI/LC_MESSAGES/messages.po
+++ b/locales/sl_SI/LC_MESSAGES/messages.po
@@ -790,13 +790,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr ""
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/sv_SE/LC_MESSAGES/messages.po
+++ b/locales/sv_SE/LC_MESSAGES/messages.po
@@ -779,13 +779,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr "Imprint &amp; personuppgifter"
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/tr_TR/LC_MESSAGES/messages.po
+++ b/locales/tr_TR/LC_MESSAGES/messages.po
@@ -778,13 +778,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr ""
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/uk_UA/LC_MESSAGES/messages.po
+++ b/locales/uk_UA/LC_MESSAGES/messages.po
@@ -785,13 +785,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr ""
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/vi_VN/LC_MESSAGES/messages.po
+++ b/locales/vi_VN/LC_MESSAGES/messages.po
@@ -773,13 +773,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr ""
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/zh_CN/LC_MESSAGES/messages.po
+++ b/locales/zh_CN/LC_MESSAGES/messages.po
@@ -771,13 +771,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr "版权说明和隐私政策"
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/locales/zh_TW/LC_MESSAGES/messages.po
+++ b/locales/zh_TW/LC_MESSAGES/messages.po
@@ -772,13 +772,13 @@ msgstr ""
 msgid "Imprint &amp; Privacy Policy"
 msgstr "作者信息 &amp; 隱私政策"
 
-msgid "automatische treinbeïnvloeding"
+msgid "ATB - Automatische Treinbeïnvloeding"
 msgstr ""
 
-msgid "Transmission voie-machine (TVM)"
+msgid "TVM - Transmission Voie-Machine"
 msgstr ""
 
-msgid "Contrôle de vitesse par balises (KVB)"
+msgid "KVB - Contrôle de Vitesse par Balises"
 msgstr ""
 
 msgid "1067mm"

--- a/styles/signals.json
+++ b/styles/signals.json
@@ -16,7 +16,7 @@
 					"usage":"main"
 				}
 			}],
-			"caption": "No information about train protection"
+			"caption": "No information available"
 		},
 		{
 			"minzoom": 2,
@@ -32,85 +32,7 @@
 					"usage":"main"
 				}
 			}],
-			"caption": "no train protection"
-		},
-		{
-			"minzoom": 2,
-			"features": [{
-				"type": "LineString",
-				"coordinates": [[10,50],[80,50]],
-				"properties": {
-					"railway":"rail",
-					"railway:pzb":"yes",
-					"usage":"main"
-				}
-			}],
-			"caption": "Punktförmige Zugbeeinflussung"
-		},
-		{
-			"minzoom": 2,
-			"features": [{
-				"type": "LineString",
-				"coordinates": [[10,50],[80,50]],
-				"properties": {
-					"railway":"rail",
-					"railway:atb":"yes",
-					"usage":"main"
-				}
-			}],
-			"caption": "automatische treinbeïnvloeding"
-		},
-		{
-			"minzoom": 2,
-			"features": [{
-				"type": "LineString",
-				"coordinates": [[10,50],[80,50]],
-				"properties": {
-					"railway":"rail",
-					"railway:lzb":"yes",
-					"usage":"main"
-				}
-			}],
-			"caption": "Linienzugbeeinflussung"
-		},
-		{
-			"minzoom": 2,
-			"features": [{
-				"type": "LineString",
-				"coordinates": [[10,50],[80,50]],
-				"properties": {
-					"railway":"rail",
-					"railway:kvb":"yes",
-					"usage":"main"
-				}
-			}],
-			"caption": "Contrôle de vitesse par balises (KVB)"
-		},
-		{
-			"minzoom": 2,
-			"features": [{
-				"type": "LineString",
-				"coordinates": [[10,50],[80,50]],
-				"properties": {
-					"railway":"rail",
-					"railway:tvm":"yes",
-					"usage":"main"
-				}
-			}],
-			"caption": "Transmission voie-machine (TVM)"
-		},
-		{
-			"minzoom": 2,
-			"features": [{
-				"type": "LineString",
-				"coordinates": [[10,50],[80,50]],
-				"properties": {
-					"railway":"rail",
-					"railway:scmt":"yes",
-					"usage":"main"
-				}
-			}],
-			"caption": "Sistema Controllo Marcia Treno (SCMT)"
+			"caption": "No train protection"
 		},
 		{
 			"minzoom": 2,
@@ -123,7 +45,7 @@
 					"usage":"main"
 				}
 			}],
-			"caption": "ETCS"
+			"caption": "ETCS - European Train Control System"
 		},
 		{
 			"minzoom": 5,
@@ -137,6 +59,84 @@
 				}
 			}],
 			"caption": "ETCS under construction"
+		},
+		{
+			"minzoom": 2,
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"railway:pzb":"yes",
+					"usage":"main"
+				}
+			}],
+			"caption": "PZB - Punktförmige Zugbeeinflussung"
+		},
+		{
+			"minzoom": 2,
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"railway:atb":"yes",
+					"usage":"main"
+				}
+			}],
+			"caption": "ATB - Automatische Treinbeïnvloeding"
+		},
+		{
+			"minzoom": 2,
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"railway:lzb":"yes",
+					"usage":"main"
+				}
+			}],
+			"caption": "LZB - Linienzugbeeinflussung"
+		},
+		{
+			"minzoom": 2,
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"railway:kvb":"yes",
+					"usage":"main"
+				}
+			}],
+			"caption": "KVB - Contrôle de Vitesse par Balises"
+		},
+		{
+			"minzoom": 2,
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"railway:tvm":"yes",
+					"usage":"main"
+				}
+			}],
+			"caption": "TVM - Transmission Voie-Machine"
+		},
+		{
+			"minzoom": 2,
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"railway:scmt":"yes",
+					"usage":"main"
+				}
+			}],
+			"caption": "SCMT - Sistema Controllo Marcia Treno"
 		},
 		{
 			"minzoom": 13,

--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -83,14 +83,14 @@ way["railway:atb-vv"=yes].tracks
 way["railway:kvb"=yes].tracks
 {
 	z-index: 5;
-	color: #B2FF33; /* pale green */
+	color: #66cc33; /* light green */
 }
 way["railway:tvm"=yes].tracks,
 way["railway:tvm"=300].tracks,
 way["railway:tvm"=430].tracks
 {
 	z-index: 6;
-	color: #78FF00; /* bright green */
+	color: #009966; /* blue-green */
 }
 way["railway:scmt"=yes].tracks
 {


### PR DESCRIPTION
Motivation:
- fix KVB/TVM colors to match actual rendering
- reorder the legend captions and make them visually uniform

![Screenshot from 2022-10-12 21-25-06](https://user-images.githubusercontent.com/21276516/195430542-b4e3df01-8b55-4674-8eff-1b47db23392c.png)
