### PR TITLE
ADD: North American PTC in legend

### DIFF
--- a/styles/signals.json
+++ b/styles/signals.json
@@ -41,6 +41,19 @@
 				"coordinates": [[10,50],[80,50]],
 				"properties": {
 					"railway":"rail",
+					"railway:ptc":"yes",
+					"usage":"main"
+				}
+			}],
+			"caption": "PTC - Positive Train Control (N. Am.)"
+		},
+		{
+			"minzoom": 2,
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
 					"railway:etcs":"yes",
 					"usage":"main"
 				}

--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -108,6 +108,11 @@ way["railway:etcs"]["railway:etcs"!=no]["railway:etcs"!=0].tracks
 	z-index: 10;
 	color: blue;
 }
+way["railway:ptc"=yes].tracks
+{
+	z-index: 10;
+	color: #cc0033;
+}
 
 /*********************************/
 /* DE crossing distant sign Bü 2 */


### PR DESCRIPTION
Follow-up of https://github.com/OpenRailwayMap/OpenRailwayMap-CartoCSS/pull/86.

I put PTC on top of the list to have the continent-wide systems on top, and keep the european systems together.

![Screenshot from 2022-10-29 12-20-13](https://user-images.githubusercontent.com/21276516/198826135-d9d2dcf3-ca2a-4125-bee3-3c7395068533.png)
