### PR TITLE
Replace grayscale layer with CSS `grayscale` rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ locales/*/*/*.json
 css/leaflet.css
 js/images
 js/leaflet.js
+js/leaflet.js.map
 
 # ignore OSM data
 *.osm
@@ -47,5 +48,3 @@ download/
 css/Leaflet.EditInOSM.css
 img/edit-in-osm.png
 js/Leaflet.EditInOSM.js
-
-js/L.TileLayer.Grayscale.js

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 SHELL = /bin/sh -e
-DEP_LEAFLET_VERSION = 0.7.7
+DEP_LEAFLET_VERSION = 1.9.3
 DEP_LEAFLET_EDITOR_FILES = download/Leaflet.EditInOSM.js download/Leaflet.EditInOSM.css download/edit-in-osm.png
-DEP_LEAFLET_GRAYSCALE_VERSION = 8675605f71f856299ebdd05a635ba1494817f5ff
 
 .PHONY: check all
 
@@ -29,27 +28,23 @@ check:
 distclean: clean
 	rm -rf download css/leaflet.css
 
-download/leaflet-$(DEP_LEAFLET_VERSION).tar.gz:
+download/leaflet-$(DEP_LEAFLET_VERSION).zip:
 	mkdir -p download
 	# do this in 2 steps to make sure only a completely downloaded file is used
-	wget -O download/leaflet.tar.gz https://github.com/Leaflet/Leaflet/archive/v$(DEP_LEAFLET_VERSION).tar.gz
-	mv download/leaflet.tar.gz download/leaflet-$(DEP_LEAFLET_VERSION).tar.gz
+	wget -O download/leaflet.zip https://leafletjs-cdn.s3.amazonaws.com/content/leaflet/v$(DEP_LEAFLET_VERSION)/leaflet.zip
+	mv download/leaflet.zip download/leaflet-$(DEP_LEAFLET_VERSION).zip
 
 $(DEP_LEAFLET_EDITOR_FILES):
 	wget -O $@.tmp https://raw.githubusercontent.com/yohanboniface/Leaflet.EditInOSM/master/$(notdir $@)
 	mv $@.tmp $@
 
-download/TileLayer.Grayscale.js:
-	mkdir -p download
-	wget -O $@.tmp https://raw.githubusercontent.com/Zverik/leaflet-grayscale/$(DEP_LEAFLET_GRAYSCALE_VERSION)/$(notdir $@)
-	mv $@.tmp $@
-
-download-deps:	download/leaflet-$(DEP_LEAFLET_VERSION).tar.gz \
+download-deps:	download/leaflet-$(DEP_LEAFLET_VERSION).zip \
 		$(DEP_LEAFLET_EDITOR_FILES)
 
-css/leaflet.css: download/leaflet-$(DEP_LEAFLET_VERSION).tar.gz
-	tar -C js --strip-components=2 -xvzf download/leaflet-$(DEP_LEAFLET_VERSION).tar.gz Leaflet-$(DEP_LEAFLET_VERSION)/dist/leaflet.js Leaflet-$(DEP_LEAFLET_VERSION)/dist/images
-	tar --to-stdout -xvzf download/leaflet-$(DEP_LEAFLET_VERSION).tar.gz Leaflet-$(DEP_LEAFLET_VERSION)/dist/leaflet.css | sed s,images/,../js/images/, > css/leaflet.css
+css/leaflet.css: download/leaflet-$(DEP_LEAFLET_VERSION).zip
+	unzip -o download/leaflet-$(DEP_LEAFLET_VERSION).zip leaflet.js leaflet.js.map -d js
+	unzip -o download/leaflet-$(DEP_LEAFLET_VERSION).zip images/ -d js/images
+	unzip -p download/leaflet-$(DEP_LEAFLET_VERSION).zip leaflet.css | sed s,images/,../js/images/, > css/leaflet.css
 
 css/Leaflet.EditInOSM.css: $(DEP_LEAFLET_EDITOR_FILES)
 	cp download/Leaflet.EditInOSM.js js/
@@ -57,7 +52,4 @@ css/Leaflet.EditInOSM.css: $(DEP_LEAFLET_EDITOR_FILES)
 	sed 's#"./edit-in-osm#"../img/edit-in-osm#' download/Leaflet.EditInOSM.css > download/Leaflet.EditInOSM.css_
 	mv download/Leaflet.EditInOSM.css_ $@
 
-js/L.TileLayer.Grayscale.js: download/TileLayer.Grayscale.js
-	cp download/TileLayer.Grayscale.js js/L.TileLayer.Grayscale.js
-
-install-deps: css/leaflet.css css/Leaflet.EditInOSM.css js/L.TileLayer.Grayscale.js
+install-deps: css/leaflet.css css/Leaflet.EditInOSM.css

--- a/css/map.css
+++ b/css/map.css
@@ -74,6 +74,10 @@ html,body
 	border-left: 1px solid black;
 }
 
+#mapFrame .leaflet-layer.grayscale img {
+	filter: grayscale(100%);
+}
+
 /* text which is shown when javascript is not activated */
 noscript p
 {
@@ -613,21 +617,21 @@ noscript p
 #locateButton
 {
 	position: absolute;
-	left: 310px;
-	top: 70px;
-	width: 26px;
-	height: 26px;
+	left: 311px;
+	top: 82px;
+	width: 30px;
+	height: 30px;
 	background-color: white;
 	background-image: url('../img/locate.png');
 	background-repeat: no-repeat;
 	background-position: 50% 50%;
 	background-size: 23px 23px;
-	-moz-border-radius: 4px;
-	-webkit-border-radius: 4px;
-	-o-border-radius: 4px;
+	-moz-border-radius: 2px;
+	-webkit-border-radius: 2px;
+	-o-border-radius: 2px;
 	border-radius: 4px;
-	border: 1px solid #aaa;
-	box-shadow: 0 1px 7px rgba(0,0,0,0.4);
+	border: 2px solid rgba(0,0,0,0.2);
+	background-clip: padding-box;
 	z-index: 1000;
 }
 

--- a/embed.php
+++ b/embed.php
@@ -40,7 +40,6 @@
 		<link rel="stylesheet" type="text/css" href="css/leaflet.css" />
 
 		<script type="text/javascript" src="js/leaflet.js"></script>
-		<script type="text/javascript" src="js/L.TileLayer.Grayscale.js"></script>
 		<?php
 			urlArgsToParam(false, $urlbase);
 		?>

--- a/index.php
+++ b/index.php
@@ -49,7 +49,6 @@
 		<script type="text/javascript" src="js/leaflet.js"></script>
 		<link rel="stylesheet" href="css/Leaflet.EditInOSM.css" />
 		<script src="js/Leaflet.EditInOSM.js"></script>
-		<script type="text/javascript" src="js/L.TileLayer.Grayscale.js"></script>
 		<?php
 			urlArgsToParam(true, $urlbase);
 		?>

--- a/js/functions.js
+++ b/js/functions.js
@@ -256,10 +256,11 @@ function mobileRedirection()
 function setupControls()
 {
 	// grayscale mapnik background layer
-	var mapnikGray = new L.TileLayer.Grayscale('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+	var mapnikGray = new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
 	{
 		attribution: _("Map data &copy; OpenStreetMap contributors"),
-		maxZoom: 19
+		maxZoom: 19,
+		className: 'grayscale'
 	}).addTo(map);
 	// normal mapnik background layer
 	var mapnik = new L.TileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',

--- a/mobile.php
+++ b/mobile.php
@@ -49,7 +49,6 @@
 		<script type="text/javascript" src="js/leaflet.js"></script>
 		<link rel="stylesheet" href="css/Leaflet.EditInOSM.css" />
 		<script src="js/Leaflet.EditInOSM.js"></script>
-		<script type="text/javascript" src="js/L.TileLayer.Grayscale.js"></script>
 		<script>L_DISABLE_3D = true;</script>
 
 		<?php


### PR DESCRIPTION
Fixes https://github.com/OpenRailwayMap/OpenRailwayMap/issues/813

This PR replaces the `L.TileLayer.Grayscale.js` Leaflet layer with a CSS rendered grayscale layer. This improves the performance of the slippy map because browser GPU rendering will be used instead of in-memory Javascript image manipulation.

I also had to upgrade the Leaflet library from 0.7.7 (released October 2015) to 1.9.3 (released November 2022)