### PR TITLE
Leaflet 1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ locales/*/*/*.json
 css/leaflet.css
 js/images
 js/leaflet.js
+js/leaflet.js.map
 
 # ignore OSM data
 *.osm

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ check:
 distclean: clean
 	rm -rf download css/leaflet.css
 
-download/leaflet-$(DEP_LEAFLET_VERSION).tar.gz:
+download/leaflet-$(DEP_LEAFLET_VERSION).zip:
 	mkdir -p download
 	# do this in 2 steps to make sure only a completely downloaded file is used
 	wget -O download/leaflet.zip https://leafletjs-cdn.s3.amazonaws.com/content/leaflet/v$(DEP_LEAFLET_VERSION)/leaflet.zip

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/sh -e
-DEP_LEAFLET_VERSION = 0.7.7
+DEP_LEAFLET_VERSION = 1.9.3
 DEP_LEAFLET_EDITOR_FILES = download/Leaflet.EditInOSM.js download/Leaflet.EditInOSM.css download/edit-in-osm.png
 DEP_LEAFLET_GRAYSCALE_VERSION = 8675605f71f856299ebdd05a635ba1494817f5ff
 
@@ -32,8 +32,8 @@ distclean: clean
 download/leaflet-$(DEP_LEAFLET_VERSION).tar.gz:
 	mkdir -p download
 	# do this in 2 steps to make sure only a completely downloaded file is used
-	wget -O download/leaflet.tar.gz https://github.com/Leaflet/Leaflet/archive/v$(DEP_LEAFLET_VERSION).tar.gz
-	mv download/leaflet.tar.gz download/leaflet-$(DEP_LEAFLET_VERSION).tar.gz
+	wget -O download/leaflet.zip https://leafletjs-cdn.s3.amazonaws.com/content/leaflet/v$(DEP_LEAFLET_VERSION)/leaflet.zip
+	mv download/leaflet.zip download/leaflet-$(DEP_LEAFLET_VERSION).zip
 
 $(DEP_LEAFLET_EDITOR_FILES):
 	wget -O $@.tmp https://raw.githubusercontent.com/yohanboniface/Leaflet.EditInOSM/master/$(notdir $@)
@@ -44,12 +44,13 @@ download/TileLayer.Grayscale.js:
 	wget -O $@.tmp https://raw.githubusercontent.com/Zverik/leaflet-grayscale/$(DEP_LEAFLET_GRAYSCALE_VERSION)/$(notdir $@)
 	mv $@.tmp $@
 
-download-deps:	download/leaflet-$(DEP_LEAFLET_VERSION).tar.gz \
+download-deps: download/leaflet-$(DEP_LEAFLET_VERSION).zip \
 		$(DEP_LEAFLET_EDITOR_FILES)
 
-css/leaflet.css: download/leaflet-$(DEP_LEAFLET_VERSION).tar.gz
-	tar -C js --strip-components=2 -xvzf download/leaflet-$(DEP_LEAFLET_VERSION).tar.gz Leaflet-$(DEP_LEAFLET_VERSION)/dist/leaflet.js Leaflet-$(DEP_LEAFLET_VERSION)/dist/images
-	tar --to-stdout -xvzf download/leaflet-$(DEP_LEAFLET_VERSION).tar.gz Leaflet-$(DEP_LEAFLET_VERSION)/dist/leaflet.css | sed s,images/,../js/images/, > css/leaflet.css
+css/leaflet.css: download/leaflet-$(DEP_LEAFLET_VERSION).zip
+	unzip -o download/leaflet-$(DEP_LEAFLET_VERSION).zip leaflet.js leaflet.js.map -d js
+	unzip -o download/leaflet-$(DEP_LEAFLET_VERSION).zip images/ -d js/images
+	unzip -p download/leaflet-$(DEP_LEAFLET_VERSION).zip leaflet.css | sed s,images/,../js/images/, > css/leaflet.css
 
 css/Leaflet.EditInOSM.css: $(DEP_LEAFLET_EDITOR_FILES)
 	cp download/Leaflet.EditInOSM.js js/

--- a/css/map.css
+++ b/css/map.css
@@ -613,10 +613,10 @@ noscript p
 #locateButton
 {
 	position: absolute;
-	left: 310px;
-	top: 70px;
-	width: 26px;
-	height: 26px;
+	left: 311px;
+	top: 82px;
+	width: 30px;
+	height: 30px;
 	background-color: white;
 	background-image: url('../img/locate.png');
 	background-repeat: no-repeat;
@@ -626,8 +626,8 @@ noscript p
 	-webkit-border-radius: 4px;
 	-o-border-radius: 4px;
 	border-radius: 4px;
-	border: 1px solid #aaa;
-	box-shadow: 0 1px 7px rgba(0,0,0,0.4);
+	border: 2px solid rgba(0,0,0,0.2);
+	background-clip: padding-box;
 	z-index: 1000;
 }
 


### PR DESCRIPTION
Split off from https://github.com/OpenRailwayMap/OpenRailwayMap/pull/814, see https://github.com/OpenRailwayMap/OpenRailwayMap/pull/814/files#r1059973240

Changes in this PR:
- Use the .zip distribution of the Leaflet library (the Github archive does not contain the javascript files in built form)
- Update the location button icon because the style has changed a bit in the new Leaflet version, and otherwise the buttons overlap and look bad.
- The Javascript source map is added because it is bundled and browsers request it.