### PR TITLE
Add ATC to legend

### DIFF
--- a/styles/signals.json
+++ b/styles/signals.json
@@ -106,6 +106,19 @@
 				"coordinates": [[10,50],[80,50]],
 				"properties": {
 					"railway":"rail",
+					"railway:atc":"yes",
+					"usage":"main"
+				}
+			}],
+			"caption": "ATC - Automatic train control"
+		},
+		{
+			"minzoom": 2,
+			"features": [{
+				"type": "LineString",
+				"coordinates": [[10,50],[80,50]],
+				"properties": {
+					"railway":"rail",
 					"railway:lzb":"yes",
 					"usage":"main"
 				}

--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -56,7 +56,9 @@ way["railway:pzb"=no]["railway:lzb"=no]["railway:etcs"=no].tracks,
 way["railway:pzb"=no]["railway:lzb"=no]["railway:etcs"=0].tracks,
 way["railway:atb"=no][!"railway:etcs"].tracks,
 way["railway:atb"=no]["railway:etcs"=no].tracks,
-way["railway:atb"=no]["railway:etcs"=0].tracks
+way["railway:atb"=no]["railway:etcs"=0].tracks,
+way["railway:atc"=no]["railway:etcs"=no].tracks,
+way["railway:atc"=no]["railway:etcs"=0].tracks
 {
 	z-index: 1;
 	color: black;
@@ -79,6 +81,11 @@ way["railway:atb-vv"=yes].tracks
 {
 	z-index: 4;
 	color: #FF8C00;
+}
+way["railway:atc"=yes].tracks
+{
+	z-index: 2;
+	color: #6600cc;
 }
 way["railway:kvb"=yes].tracks
 {


### PR DESCRIPTION
as suggested in #824 added train protection system ATC to the legend. 
I expect it to be used as well for non-european systems, so I used a nonexisting colour. 
The "no-train-protection" case is at the moment the try to distinguish between european and non-european system so I expect that etcs-tags only occur in europe (so missing out the [!"railway:etcs"] case for it). 
Edit: just saw that etcs is also used in various non-european countries. So what's better? Remove the no-protection condition again or live with maybe false-negatives (there could be train protection even when "no" is shown on the map)?