### PR TITLE
MOD: changed ZSI 127 color to brown to resolve conflict

### DIFF
--- a/styles/signals.json
+++ b/styles/signals.json
@@ -103,6 +103,19 @@
 			"minzoom": 2,
 			"features": [{
 				"type": "LineString",
+				"coordinates": [[10, 50],[80,50]],
+				"properties": {
+					"railway":"rail",
+					"railway:zsi127":"yes",
+					"usage": "main"
+				}
+			}],
+			"caption": "ZSI 127 - Trainguard ZSI 127"
+		},
+		{
+			"minzoom": 2,
+			"features": [{
+				"type": "LineString",
 				"coordinates": [[10,50],[80,50]],
 				"properties": {
 					"railway":"rail",
@@ -163,19 +176,6 @@
 				}
 			}],
 			"caption": "SCMT - Sistema Controllo Marcia Treno"
-		},
-		{
-			"minzoom": 2,
-			"features": [{
-				"type": "LineString",
-				"coordinates": [[10, 50],[80,50]],
-				"properties": {
-					"railway":"rail",
-					"railway:zsi127":"yes",
-					"usage": "main"
-				}
-			}],
-			"caption": "ZSI 127 - Trainguard ZSI 127"
 		},
 		{
 			"minzoom": 13,

--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -123,7 +123,7 @@ way["railway:ptc"=yes].tracks
 way["railway:zsi127"="yes"].tracks
 {
 	z-index: 3;
-	color: #5c1ccb;
+	color: #884400;
 }
 
 /*********************************/


### PR DESCRIPTION
The recently added ZSI 127 has a violet color in the legend. It matches the color of the scandinavian ATC; since the rendering part of ZSI 127 in the Carto repository has not been added yet, I tought of changing the color now to avoid bigger fixes later.

I picked up brown because ZSI 127 is only meant to be used in the narrow-gauge network in Switzerland, which will be 100% blue because of ETCS, so I mainly wanted to avoid blue (and Italy's pink). Being a German-speaking region I thought of picking up a color that would reflect this inheritance.