### PR TITLE
Switch to API version 2

### DIFF
--- a/js/bitmap-map.js
+++ b/js/bitmap-map.js
@@ -8,7 +8,7 @@ See https://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 
 window.openrailwaymap = {
 	'root': params['urlbase'],
-	'apiUrl': 'https://api.openrailwaymap.org/',
+	'apiUrl': 'https://api.openrailwaymap.org/v2/',
 	'tiledir': 'https://{s}.tiles.openrailwaymap.org/',
 	'availableStyles': {
 		"standard": "Infrastructure",

--- a/js/mobile.js
+++ b/js/mobile.js
@@ -8,7 +8,7 @@ See https://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 
 window.openrailwaymap = {
 	'root': params['urlbase'],
-	'apiUrl': 'https://api.openrailwaymap.org/',
+	'apiUrl': 'https://api.openrailwaymap.org/v2/',
 	'tiledir': 'https://{s}.tiles.openrailwaymap.org/',
 	'availableStyles': {
 		"standard": "Infrastructure",

--- a/js/search.js
+++ b/js/search.js
@@ -104,7 +104,7 @@ function Search(map, box, bar, searchButton, clearButton, mobilemenu)
 						queryRef(response);
 				});
 			} else {
-				this.sendRequest("facility", "uicref=" + encodeURIComponent(input), queryRef);
+				this.sendRequest("facility", "uic_ref=" + encodeURIComponent(input), queryRef);
 			}
 		}
 	}
@@ -135,19 +135,19 @@ function Search(map, box, bar, searchButton, clearButton, mobilemenu)
 
 				if (inner)
 					result.innerHTML = '<b>' + escapeForHTML(inner) + '</b>';
-
-				if (results[i]['type'] != null && typeof results[i]['type'] != undefined && this.typeMapping[results[i]['type']] != null)
-					result.innerHTML += '&nbsp;' + escapeForHTML(_(this.typeMapping[results[i]['type']]));
+				var resultType = this.getResultType(results[i]);
+				if (resultType != null)
+					result.innerHTML += '&nbsp;' + escapeForHTML(_(this.typeMapping[resultType]));
 				if (results[i]['operator'] != null && typeof results[i]['operator'] != undefined)
 					result.innerHTML += '<br /><dfn>' + escapeForHTML(results[i]['operator']) + '</dfn>';
-				if (results[i]['ref'] && (results[i]['type'] == 'station' || results[i]['type'] == 'halt' || results[i]['type'] == 'junction' ||
-						results[i]['type'] == 'spur_junction' || results[i]['type'] == 'yard' || results[i]['type'] == 'crossover' ||
-						results[i]['type'] == 'site' || results[i]['type'] == 'service_station' || results[i]['type'] == 'tram_stop'))
+				if (results[i]['ref'] && (resultType == 'station' || resultType == 'halt' || resultType == 'junction' ||
+						resultType == 'spur_junction' || resultType == 'yard' || resultType == 'crossover' ||
+						resultType == 'site' || resultType == 'service_station' || resultType == 'tram_stop'))
 					result.innerHTML += ' <i>[' + escapeForHTML(results[i]['ref']) + ']</i>';
 
 				selfSearch = this;
-				var lon = Number.parseFloat(results[i]['lon']);
-				var lat = Number.parseFloat(results[i]['lat']);
+				var lon = Number.parseFloat(results[i]['longitude']);
+				var lat = Number.parseFloat(results[i]['latitude']);
 				if (!Number.isNaN(lon) && !Number.isNaN(lat)) {
 					result.setAttribute('class', 'resultEntry');
 					result.onclick = new Function("selfSearch.showResult(" + lon + ", " + lat + ");");
@@ -161,6 +161,19 @@ function Search(map, box, bar, searchButton, clearButton, mobilemenu)
 			loadingIndicator.innerHTML = this.loading;
 			this.bar.appendChild(loadingIndicator);
 		}
+	}
+
+	// Get type of railway feature (station, halt, …) from keys railway, disused:railway etc.
+	this.getResultType = function(result_entry)
+	{
+		var keys = ["railway", "disused:railway", "construction:railway", "abandoned:railway", "razed:railway", "proposed:railway"];
+		for (var i = 0; i < keys.length; ++i) {
+			var value = result_entry[keys[i]];
+			if (value != null && typeof value != undefined && this.typeMapping[value] != null) {
+				return value;
+			}
+		}
+		return null;
 	}
 
 	// finishes adding more results to the result list


### PR DESCRIPTION
I rewrote the current [API with some modifications](https://github.com/OpenRailwayMap/OpenRailwayMap-API) because the existing API is slow (reason: database queries do not make use of indexes). You can try the new API at `https://api.openrailwaymap.org/v2/`.

Examples:

* `https://api.openrailwaymap.org/v2/facility?name=Karlsruhe`
* `https://api.openrailwaymap.org/v2/facility?ref=RK`
* `https://api.openrailwaymap.org/v2/facility?uic_ref=<UIC ref>`
* `https://api.openrailwaymap.org/v2/facility?q=<string>` (search by name, `railway:ref` and UIC number)
* `https://api.openrailwaymap.org/v2/milestone?ref=2134&position=24.6`: search for milestones near km 24.6 on railway line with `ref=2134`.

Main changes to the API are:

* All queries are fast.
* Searching stations by name makes use of the ranking used for map rendering.
* Disused, abandoned, razed, proposed stations and stations under construction (applies to halts, junctions etc. as well) are supported.
* Search by name includes all languages.
* Search by railway line and mileage works again.
* Network length API removed because these queries are either slow or require pre-processing.

When this pull request is merged, I will disable the old API on the server and update the documentation on the wiki.