### PR TITLE
Change signalling layer name

### DIFF
--- a/js/bitmap-map.js
+++ b/js/bitmap-map.js
@@ -13,7 +13,7 @@ window.openrailwaymap = {
 	'availableStyles': {
 		"standard": "Infrastructure",
 		"maxspeed": "Maxspeeds",
-		"signals": "Signalling",
+		"signals": "Signalling and train protection",
 		"electrified": "Electrification (beta)",
 		"gauge": "Track gauge (beta)",
 	}

--- a/js/mobile.js
+++ b/js/mobile.js
@@ -13,7 +13,7 @@ window.openrailwaymap = {
 	'availableStyles': {
 		"standard": "Infrastructure",
 		"maxspeed": "Maxspeeds",
-		"signals": "Signalling",
+		"signals": "Signalling and train protection",
 		"electrified": "Electrification (beta)",
 		"gauge": "Track gauge (beta)",
 	}

--- a/locales/ca_ES/LC_MESSAGES/messages.po
+++ b/locales/ca_ES/LC_MESSAGES/messages.po
@@ -148,7 +148,7 @@ msgstr "fa %s"
 msgid "Infrastructure"
 msgstr "Infraestructura"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Senyalització"
 
 msgid "Maxspeeds"

--- a/locales/cs_CZ/LC_MESSAGES/messages.po
+++ b/locales/cs_CZ/LC_MESSAGES/messages.po
@@ -153,7 +153,7 @@ msgstr "před %s"
 msgid "Infrastructure"
 msgstr "Infrastruktura"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Signalizace"
 
 msgid "Maxspeeds"

--- a/locales/da_DK/LC_MESSAGES/messages.po
+++ b/locales/da_DK/LC_MESSAGES/messages.po
@@ -145,7 +145,7 @@ msgstr "%s siden"
 msgid "Infrastructure"
 msgstr ""
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr ""
 
 msgid "Maxspeeds"

--- a/locales/de_DE/LC_MESSAGES/messages.po
+++ b/locales/de_DE/LC_MESSAGES/messages.po
@@ -150,7 +150,7 @@ msgstr "vor %s"
 msgid "Infrastructure"
 msgstr "Infrastruktur"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Signale und Sicherungssysteme"
 
 msgid "Maxspeeds"

--- a/locales/el_GR/LC_MESSAGES/messages.po
+++ b/locales/el_GR/LC_MESSAGES/messages.po
@@ -146,7 +146,7 @@ msgstr "πριν από %s"
 msgid "Infrastructure"
 msgstr "Υποδομή"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Σηματοδότηση"
 
 msgid "Maxspeeds"

--- a/locales/en_GB/LC_MESSAGES/messages.po
+++ b/locales/en_GB/LC_MESSAGES/messages.po
@@ -144,8 +144,8 @@ msgstr "%s ago"
 msgid "Infrastructure"
 msgstr "Infrastructure"
 
-msgid "Signalling"
-msgstr "Signalling"
+msgid "Signalling and train protection"
+msgstr "Signalling and train protection"
 
 msgid "Maxspeeds"
 msgstr "Max speeds"

--- a/locales/es_ES/LC_MESSAGES/messages.po
+++ b/locales/es_ES/LC_MESSAGES/messages.po
@@ -147,7 +147,7 @@ msgstr "hace %s"
 msgid "Infrastructure"
 msgstr "Infraestructura"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Señalización"
 
 msgid "Maxspeeds"

--- a/locales/fi_FI/LC_MESSAGES/messages.po
+++ b/locales/fi_FI/LC_MESSAGES/messages.po
@@ -144,7 +144,7 @@ msgstr "%s sitten"
 msgid "Infrastructure"
 msgstr "Infrastruktuuri"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Opastimet"
 
 msgid "Maxspeeds"

--- a/locales/fr_FR/LC_MESSAGES/messages.po
+++ b/locales/fr_FR/LC_MESSAGES/messages.po
@@ -147,7 +147,7 @@ msgstr "il y a %s"
 msgid "Infrastructure"
 msgstr "Infrastructure"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Signalisation"
 
 msgid "Maxspeeds"

--- a/locales/hu_HU/LC_MESSAGES/messages.po
+++ b/locales/hu_HU/LC_MESSAGES/messages.po
@@ -145,7 +145,7 @@ msgstr "ennyi idővel ezelőtt: %s"
 msgid "Infrastructure"
 msgstr "Insfrastruktúra"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Jelzőrendszer"
 
 msgid "Maxspeeds"

--- a/locales/ja_JP/LC_MESSAGES/messages.po
+++ b/locales/ja_JP/LC_MESSAGES/messages.po
@@ -141,7 +141,7 @@ msgstr "%s 前"
 msgid "Infrastructure"
 msgstr "インフラストラクチャ"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "信号"
 
 msgid "Maxspeeds"

--- a/locales/lt_LT/LC_MESSAGES/messages.po
+++ b/locales/lt_LT/LC_MESSAGES/messages.po
@@ -152,7 +152,7 @@ msgstr "prieš %s"
 msgid "Infrastructure"
 msgstr "Infrastruktūra"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Signalizacija"
 
 msgid "Maxspeeds"

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -136,7 +136,7 @@ msgstr ""
 msgid "Infrastructure"
 msgstr ""
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr ""
 
 msgid "Maxspeeds"

--- a/locales/nl_NL/LC_MESSAGES/messages.po
+++ b/locales/nl_NL/LC_MESSAGES/messages.po
@@ -145,7 +145,7 @@ msgstr "%s geleden"
 msgid "Infrastructure"
 msgstr "Infrastructuur"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Seinen"
 
 msgid "Maxspeeds"

--- a/locales/nqo_GN/LC_MESSAGES/messages.po
+++ b/locales/nqo_GN/LC_MESSAGES/messages.po
@@ -142,7 +142,7 @@ msgstr "%s ߓߘߊ߫ ߕߊ߬ߡߌ߲߬"
 msgid "Infrastructure"
 msgstr "ߖߏߣߡߊ"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "ߟߊ߬ߟߐ߲߬ߠߌ"
 
 msgid "Maxspeeds"

--- a/locales/pl_PL/LC_MESSAGES/messages.po
+++ b/locales/pl_PL/LC_MESSAGES/messages.po
@@ -157,7 +157,7 @@ msgstr "%s temu"
 msgid "Infrastructure"
 msgstr "Infrastruktura"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Sygnalizacja"
 
 msgid "Maxspeeds"

--- a/locales/pt_PT/LC_MESSAGES/messages.po
+++ b/locales/pt_PT/LC_MESSAGES/messages.po
@@ -144,7 +144,7 @@ msgstr "%s atrás"
 msgid "Infrastructure"
 msgstr "Infraestrutura"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Sinalética"
 
 msgid "Maxspeeds"

--- a/locales/ru_RU/LC_MESSAGES/messages.po
+++ b/locales/ru_RU/LC_MESSAGES/messages.po
@@ -164,7 +164,7 @@ msgstr "%s назад"
 msgid "Infrastructure"
 msgstr "Инфраструктура"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Сигнализация"
 
 msgid "Maxspeeds"

--- a/locales/sl_SI/LC_MESSAGES/messages.po
+++ b/locales/sl_SI/LC_MESSAGES/messages.po
@@ -156,7 +156,7 @@ msgstr "%s nazaj"
 msgid "Infrastructure"
 msgstr "Infrastruktura"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Signalizacija"
 
 msgid "Maxspeeds"

--- a/locales/sv_SE/LC_MESSAGES/messages.po
+++ b/locales/sv_SE/LC_MESSAGES/messages.po
@@ -145,7 +145,7 @@ msgstr "%s sedan"
 msgid "Infrastructure"
 msgstr "Infrastruktur"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Signalering"
 
 msgid "Maxspeeds"

--- a/locales/tr_TR/LC_MESSAGES/messages.po
+++ b/locales/tr_TR/LC_MESSAGES/messages.po
@@ -144,7 +144,7 @@ msgstr "%s önce"
 msgid "Infrastructure"
 msgstr "Altyapı"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Sinyalizasyon"
 
 msgid "Maxspeeds"

--- a/locales/uk_UA/LC_MESSAGES/messages.po
+++ b/locales/uk_UA/LC_MESSAGES/messages.po
@@ -151,7 +151,7 @@ msgstr "%s тому назад"
 msgid "Infrastructure"
 msgstr "Інфраструктура"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Сигнали"
 
 msgid "Maxspeeds"

--- a/locales/vi_VN/LC_MESSAGES/messages.po
+++ b/locales/vi_VN/LC_MESSAGES/messages.po
@@ -139,7 +139,7 @@ msgstr "cách đây %s"
 msgid "Infrastructure"
 msgstr "Cơ sở hạ tầng"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "Báo hiệu"
 
 msgid "Maxspeeds"

--- a/locales/zh_CN/LC_MESSAGES/messages.po
+++ b/locales/zh_CN/LC_MESSAGES/messages.po
@@ -137,7 +137,7 @@ msgstr "%s前"
 msgid "Infrastructure"
 msgstr "基础设施"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "信号"
 
 msgid "Maxspeeds"

--- a/locales/zh_TW/LC_MESSAGES/messages.po
+++ b/locales/zh_TW/LC_MESSAGES/messages.po
@@ -138,7 +138,7 @@ msgstr "%s前"
 msgid "Infrastructure"
 msgstr "設施"
 
-msgid "Signalling"
+msgid "Signalling and train protection"
 msgstr "號誌"
 
 msgid "Maxspeeds"


### PR DESCRIPTION
As by issue #845 changed the name of the Signalling layer. Used "train protection" instead of "train protection systems" to keep it a bit shorter. Now the german translation matches as well the english "original"... 
Other translation msgstr were not modified, only the "original" msgid patched to the new original english version.