### PR TITLE
Render fouling points in josm-style

### DIFF
--- a/styles/josm-additional.mapcss
+++ b/styles/josm-additional.mapcss
@@ -133,7 +133,7 @@ node|z14-[railway=signal]["railway:signal:direction"]["railway:signal:speed_limi
 	icon-image: "icons/de/lf7-empty-sign-32.png";
 }
 
-node|z16-[railway=signal][!"railway:signal:direction"]
+node|z16-[railway=signal][!"railway:signal:direction"][!"railway:signal:fouling_point"]
 {
 	z-index: 1000;
 	icon-image: "presets/misc/deprecated.svg";

--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -643,6 +643,21 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:shunting"=
 	allow-overlap: true;
 }
 
+/*********************************************/
+/* Fouling point marker Ra12 in german style */
+/*********************************************/
+node|z17-[railway=signal]["railway:signal:fouling_point"="DE-ESO:ra12"],
+node|z17-[railway=signal]["railway:signal:fouling_point"="DE-BOStrab:sh6"],
+node|z17-[railway=signal]["railway:signal:fouling_point"="PL-PKP:w17"]
+{
+	z-index: 2800;
+	icon-image: "icons/de/ra12.png";
+	icon-width: 16;
+	icon-height: 11;
+	text-allow-overlap: true;
+	allow-overlap: true;
+}
+
 /*********************************************************/
 /* DE minor light dwarf signals type Sh                  */
 /* -also all other sh light signals that cannot show sh1 */


### PR DESCRIPTION
As described in #689 fouling points in germany were not rendered, but (as they are often not tagged with railway:signal:direction) often as a "deprecated" symbol. 

- Adds the rendering itself for ESO, BOStrab and PKP fouling points (they all look the same)
- Doesn't care about direction tag in this special case