### PR TITLE
messages.pot:  added capital letter

### DIFF
--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -517,10 +517,10 @@ msgstr ""
 msgid "Finland"
 msgstr ""
 
-msgid "train protection"
+msgid "Train protection"
 msgstr ""
 
-msgid "no train protection"
+msgid "No train protection"
 msgstr ""
 
 msgid "crossing signal type To"


### PR DESCRIPTION
Edited msgid, added capital letter: "No train protection" and "Train protection".