### PR TITLE
Remove JS grayscale dependency and use CSS filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 SHELL = /bin/sh -e
 DEP_LEAFLET_VERSION = 0.7.7
 DEP_LEAFLET_EDITOR_FILES = download/Leaflet.EditInOSM.js download/Leaflet.EditInOSM.css download/edit-in-osm.png
-DEP_LEAFLET_GRAYSCALE_VERSION = 8675605f71f856299ebdd05a635ba1494817f5ff
 
 .PHONY: check all
 
@@ -39,11 +38,6 @@ $(DEP_LEAFLET_EDITOR_FILES):
 	wget -O $@.tmp https://raw.githubusercontent.com/yohanboniface/Leaflet.EditInOSM/master/$(notdir $@)
 	mv $@.tmp $@
 
-download/TileLayer.Grayscale.js:
-	mkdir -p download
-	wget -O $@.tmp https://raw.githubusercontent.com/Zverik/leaflet-grayscale/$(DEP_LEAFLET_GRAYSCALE_VERSION)/$(notdir $@)
-	mv $@.tmp $@
-
 download-deps:	download/leaflet-$(DEP_LEAFLET_VERSION).tar.gz \
 		$(DEP_LEAFLET_EDITOR_FILES)
 
@@ -57,7 +51,4 @@ css/Leaflet.EditInOSM.css: $(DEP_LEAFLET_EDITOR_FILES)
 	sed 's#"./edit-in-osm#"../img/edit-in-osm#' download/Leaflet.EditInOSM.css > download/Leaflet.EditInOSM.css_
 	mv download/Leaflet.EditInOSM.css_ $@
 
-js/L.TileLayer.Grayscale.js: download/TileLayer.Grayscale.js
-	cp download/TileLayer.Grayscale.js js/L.TileLayer.Grayscale.js
-
-install-deps: css/leaflet.css css/Leaflet.EditInOSM.css js/L.TileLayer.Grayscale.js
+install-deps: css/leaflet.css css/Leaflet.EditInOSM.css

--- a/css/map.css
+++ b/css/map.css
@@ -74,6 +74,11 @@ html,body
 	border-left: 1px solid black;
 }
 
+.grayscale
+{
+	filter: grayscale(1);
+}
+
 /* text which is shown when javascript is not activated */
 noscript p
 {

--- a/css/map.css
+++ b/css/map.css
@@ -76,6 +76,7 @@ html,body
 
 .grayscale
 {
+	-webkit-filter: grayscale(1);
 	filter: grayscale(1);
 }
 

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -99,6 +99,11 @@ html,body
 	bottom: 0px;
 }
 
+.grayscale
+{
+	filter: grayscale(1);
+}
+
 /* hidden menu */
 .menuOut
 {

--- a/css/mobile.css
+++ b/css/mobile.css
@@ -101,6 +101,7 @@ html,body
 
 .grayscale
 {
+	-webkit-filter: grayscale(1);
 	filter: grayscale(1);
 }
 

--- a/embed.php
+++ b/embed.php
@@ -40,7 +40,6 @@
 		<link rel="stylesheet" type="text/css" href="css/leaflet.css" />
 
 		<script type="text/javascript" src="js/leaflet.js"></script>
-		<script type="text/javascript" src="js/L.TileLayer.Grayscale.js"></script>
 		<?php
 			urlArgsToParam(false, $urlbase);
 		?>

--- a/index.php
+++ b/index.php
@@ -49,7 +49,6 @@
 		<script type="text/javascript" src="js/leaflet.js"></script>
 		<link rel="stylesheet" href="css/Leaflet.EditInOSM.css" />
 		<script src="js/Leaflet.EditInOSM.js"></script>
-		<script type="text/javascript" src="js/L.TileLayer.Grayscale.js"></script>
 		<?php
 			urlArgsToParam(true, $urlbase);
 		?>

--- a/js/functions.js
+++ b/js/functions.js
@@ -256,9 +256,10 @@ function mobileRedirection()
 function setupControls()
 {
 	// grayscale mapnik background layer
-	var mapnikGray = new L.TileLayer.Grayscale('https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+	var mapnikGray = new L.TileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 	{
 		attribution: _("Map data &copy; OpenStreetMap contributors"),
+		className: "grayscale",
 		maxZoom: 19
 	}).addTo(map);
 	// normal mapnik background layer

--- a/mobile.php
+++ b/mobile.php
@@ -49,7 +49,6 @@
 		<script type="text/javascript" src="js/leaflet.js"></script>
 		<link rel="stylesheet" href="css/Leaflet.EditInOSM.css" />
 		<script src="js/Leaflet.EditInOSM.js"></script>
-		<script type="text/javascript" src="js/L.TileLayer.Grayscale.js"></script>
 		<script>L_DISABLE_3D = true;</script>
 
 		<?php


### PR DESCRIPTION
Using CSS Filter Effects instead of having an extra JS dependency for grayscaling the base map increases the perceived speed as it moves the work from the JS to the browser-intern implementation.
This also removes the need to keep `TileLayer.Grayscale.js` in the pipeline.
I'd say that after 9 years of availability (see [caniuse](//caniuse.com/css-filters)) it's time to make the switch.