### PR TITLE
Update python versions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
     - name: checkout

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,7 +34,7 @@ jobs:
     - name: python deps
       run: |
         python -m pip install --upgrade pip
-        pip install 'cairocffi<1' 'pillow<6' ply pojson polib
+        pip install 'cairocffi<1' 'pillow<=10' ply pojson polib
     - name: Build
       run: make
     - name: Tests


### PR DESCRIPTION
The workflow works yet, but python 3.7 has reached the end of updates last year. Added python 3.10 as that seems to be the standard version in ubuntu 22.04.