### PR TITLE
add Zuglängentafel

### DIFF
--- a/josm-presets/de-signals-eso.xml
+++ b/josm-presets/de-signals-eso.xml
@@ -2033,6 +2033,33 @@ See https://wiki.openstreetmap.org/wiki/OpenRailwayMap for details.
 					de.display_values="Mastbauform,Zwergsignal"
 					/>
 			</item>
+			<item name="Train length board" de.name="Zuglängentafel" type="node">
+				<label text="Train length board" de.text="Zuglängentafel" />
+				<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />
+				<space />
+				<key key="railway"
+					value="signal" />
+				<check key="railway:signal:stop:deactivated"
+					text="Out of order"
+					de.text="Ungültigkeitskreuz"
+					/>
+				<combo key="railway:signal:position"
+					text="Signal position"
+					de.text="Signalstandort"
+					values="left,right"
+					de.display_values="Links von Wegrichtung,Rechts von Wegrichtung"
+					display_values="left in direction of OSM way,right in direction of OSM way"
+					/>
+				<reference ref="direction_fw_bw" />
+				<key key="railway:signal:stop"
+					value="DE-ESO:zuglänge" />
+				<key key="railway:signal:stop:form"
+					value="sign" />
+				<text key="railway:signal:stop:caption"
+					text="text on subsidiary plate"
+					de.text="Zusatztext"
+					/>
+			</item>
 			<item name="Stop Marker (Ne 5)" de.name="Haltetafel (Ne 5)" icon="de/ne5-ds301-32.png" type="node">
 				<label text="Stop Marker (Ne 5)" de.text="Haltetafel (Ne 5)" />
 				<label text="This signal is being mapped as a node on the track." de.text="Wird als Punkt auf dem Gleis erfasst." />

--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -438,9 +438,9 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:stop_deman
 	allow-overlap: true;
 }
 
-/****************************/
-/* DE stop post Ne 5 as sign*/
-/****************************/
+/*****************************/
+/* DE stop post Ne 5 as sign */
+/*****************************/
 node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:stop"="DE-ESO:ne5"]["railway:signal:stop:form"=sign]
 {
 	z-index: 1000;
@@ -459,6 +459,16 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:stop"="DE-
 
 @supports (user-agent: josm) {
 	node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:stop"="DE-ESO:ne5"]["railway:signal:stop:form"=sign]
+	{
+		text-offset-x: eval(length(tag("railway:signal:stop:caption")) * (0 - 3) - 6);
+		text-offset-y: -12;
+	}
+}
+/*******************************************/
+/* DE stop post train length board as sign */
+/*******************************************/
+@supports (user-agent: josm) {
+	node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:stop"="DE-ESO:zuglänge"]["railway:signal:stop:form"=sign]
 	{
 		text-offset-x: eval(length(tag("railway:signal:stop:caption")) * (0 - 3) - 6);
 		text-offset-y: -12;

--- a/styles/signals.mapcss
+++ b/styles/signals.mapcss
@@ -468,8 +468,9 @@ node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:stop"="DE-
 /* DE stop post train length board as sign */
 /*******************************************/
 @supports (user-agent: josm) {
-	node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:stop"="DE-ESO:zuglänge"]["railway:signal:stop:form"=sign]
+	node|z17-[railway=signal]["railway:signal:direction"]["railway:signal:stop"="DE-ESO:zuglänge"]["railway:signal:stop:form"=sign]["railway:signal:stop:caption"]
 	{
+		text: "railway:signal:stop:caption";
 		text-offset-x: eval(length(tag("railway:signal:stop:caption")) * (0 - 3) - 6);
 		text-offset-y: -12;
 	}


### PR DESCRIPTION
The Zuglängentafel (train length board) was added to the wiki and often found "in the wild". Added josm preset and basic rendering (only text). 
No ideas for further rendering yet.